### PR TITLE
Fix names and types in proof verifier

### DIFF
--- a/hash_chainer.go
+++ b/hash_chainer.go
@@ -27,7 +27,7 @@ type hashChainer struct {
 // border. Assumes |proof| hashes are ordered from lower levels to upper, and
 // |seed| is the initial subtree/leaf hash on the path located at the specified
 // |index| on its level.
-func (c hashChainer) chainInner(seed []byte, proof [][]byte, index int64) []byte {
+func (c hashChainer) chainInner(seed []byte, proof [][]byte, index uint64) []byte {
 	for i, h := range proof {
 		if (index>>uint(i))&1 == 0 {
 			seed = c.hasher.HashChildren(seed, h)
@@ -41,7 +41,7 @@ func (c hashChainer) chainInner(seed []byte, proof [][]byte, index int64) []byte
 // chainInnerRight computes a subtree hash like chainInner, but only takes
 // hashes to the left from the path into consideration, which effectively means
 // the result is a hash of the corresponding earlier version of this subtree.
-func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, index int64) []byte {
+func (c hashChainer) chainInnerRight(seed []byte, proof [][]byte, index uint64) []byte {
 	for i, h := range proof {
 		if (index>>uint(i))&1 == 1 {
 			seed = c.hasher.HashChildren(h, seed)

--- a/log_verifier.go
+++ b/log_verifier.go
@@ -56,8 +56,8 @@ func NewLogVerifier(hasher LogHasher) LogVerifier {
 // VerifyInclusion verifies the correctness of the inclusion proof for the leaf
 // with the specified hash and index, relatively to the tree of the given size
 // and root hash. Requires 0 <= index < size.
-func (v LogVerifier) VerifyInclusion(index, size uint64, proof [][]byte, root []byte, leafHash []byte) error {
-	calcRoot, err := v.RootFromInclusionProof(index, size, proof, leafHash)
+func (v LogVerifier) VerifyInclusion(index, size uint64, leafHash []byte, proof [][]byte, root []byte) error {
+	calcRoot, err := v.RootFromInclusionProof(index, size, leafHash, proof)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (v LogVerifier) VerifyInclusion(index, size uint64, proof [][]byte, root []
 // RootFromInclusionProof calculates the expected root hash for a tree of the
 // given size, provided a leaf index and hash with the corresponding inclusion
 // proof. Requires 0 <= index < size.
-func (v LogVerifier) RootFromInclusionProof(index, size uint64, proof [][]byte, leafHash []byte) ([]byte, error) {
+func (v LogVerifier) RootFromInclusionProof(index, size uint64, leafHash []byte, proof [][]byte) ([]byte, error) {
 	if index >= size {
 		return nil, fmt.Errorf("index is beyond size: %d >= %d", index, size)
 	}

--- a/log_verifier.go
+++ b/log_verifier.go
@@ -53,9 +53,9 @@ func NewLogVerifier(hasher LogHasher) LogVerifier {
 	return LogVerifier{hasher}
 }
 
-// VerifyInclusionProof verifies the correctness of the proof given the passed
+// VerifyInclusion verifies the correctness of the proof given the passed
 // in information about the tree and leaf.
-func (v LogVerifier) VerifyInclusionProof(index, size uint64, proof [][]byte, root []byte, leafHash []byte) error {
+func (v LogVerifier) VerifyInclusion(index, size uint64, proof [][]byte, root []byte, leafHash []byte) error {
 	calcRoot, err := v.RootFromInclusionProof(index, size, proof, leafHash)
 	if err != nil {
 		return err
@@ -91,9 +91,9 @@ func (v LogVerifier) RootFromInclusionProof(index, size uint64, proof [][]byte, 
 	return res, nil
 }
 
-// VerifyConsistencyProof checks that the passed in consistency proof is valid
+// VerifyConsistency checks that the passed in consistency proof is valid
 // between the passed in tree sizes. Accepts size2 >= size1 >= 0.
-func (v LogVerifier) VerifyConsistencyProof(size1, size2 uint64, root1, root2 []byte, proof [][]byte) error {
+func (v LogVerifier) VerifyConsistency(size1, size2 uint64, root1, root2 []byte, proof [][]byte) error {
 	switch {
 	case size2 < size1:
 		return fmt.Errorf("size2 (%d) < size1 (%d)", size1, size2)

--- a/log_verifier.go
+++ b/log_verifier.go
@@ -53,8 +53,9 @@ func NewLogVerifier(hasher LogHasher) LogVerifier {
 	return LogVerifier{hasher}
 }
 
-// VerifyInclusion verifies the correctness of the proof given the passed
-// in information about the tree and leaf.
+// VerifyInclusion verifies the correctness of the inclusion proof for the leaf
+// with the specified hash and index, relatively to the tree of the given size
+// and root hash. Requires 0 <= index < size.
 func (v LogVerifier) VerifyInclusion(index, size uint64, proof [][]byte, root []byte, leafHash []byte) error {
 	calcRoot, err := v.RootFromInclusionProof(index, size, proof, leafHash)
 	if err != nil {
@@ -69,9 +70,9 @@ func (v LogVerifier) VerifyInclusion(index, size uint64, proof [][]byte, root []
 	return nil
 }
 
-// RootFromInclusionProof calculates the expected tree root given the proof and leaf.
-// Leaf index starts at 0. Tree size is the number of leaf nodes in the tree.
-// proof is an array of neighbor nodes from the bottom to the root.
+// RootFromInclusionProof calculates the expected root hash for a tree of the
+// given size, provided a leaf index and hash with the corresponding inclusion
+// proof. Requires 0 <= index < size.
 func (v LogVerifier) RootFromInclusionProof(index, size uint64, proof [][]byte, leafHash []byte) ([]byte, error) {
 	if index >= size {
 		return nil, fmt.Errorf("index is beyond size: %d >= %d", index, size)
@@ -91,8 +92,9 @@ func (v LogVerifier) RootFromInclusionProof(index, size uint64, proof [][]byte, 
 	return res, nil
 }
 
-// VerifyConsistency checks that the passed in consistency proof is valid
-// between the passed in tree sizes. Accepts size2 >= size1 >= 0.
+// VerifyConsistency checks that the passed-in consistency proof is valid
+// between the passed in tree sizes, with respect to the corresponding root
+// hashes. Requires 0 <= size1 <= size2.
 func (v LogVerifier) VerifyConsistency(size1, size2 uint64, root1, root2 []byte, proof [][]byte) error {
 	switch {
 	case size2 < size1:

--- a/log_verifier.go
+++ b/log_verifier.go
@@ -55,8 +55,8 @@ func NewLogVerifier(hasher LogHasher) LogVerifier {
 
 // VerifyInclusionProof verifies the correctness of the proof given the passed
 // in information about the tree and leaf.
-func (v LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]byte, root []byte, leafHash []byte) error {
-	calcRoot, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leafHash)
+func (v LogVerifier) VerifyInclusionProof(index, size int64, proof [][]byte, root []byte, leafHash []byte) error {
+	calcRoot, err := v.RootFromInclusionProof(index, size, proof, leafHash)
 	if err != nil {
 		return err
 	}
@@ -70,28 +70,28 @@ func (v LogVerifier) VerifyInclusionProof(leafIndex, treeSize int64, proof [][]b
 }
 
 // RootFromInclusionProof calculates the expected tree root given the proof and leaf.
-// leafIndex starts at 0.  treeSize is the number of nodes in the tree.
+// Leaf index starts at 0. Tree size is the number of leaf nodes in the tree.
 // proof is an array of neighbor nodes from the bottom to the root.
-func (v LogVerifier) RootFromInclusionProof(leafIndex, treeSize int64, proof [][]byte, leafHash []byte) ([]byte, error) {
+func (v LogVerifier) RootFromInclusionProof(index, size int64, proof [][]byte, leafHash []byte) ([]byte, error) {
 	switch {
-	case leafIndex < 0:
-		return nil, fmt.Errorf("leafIndex %d < 0", leafIndex)
-	case treeSize < 0:
-		return nil, fmt.Errorf("treeSize %d < 0", treeSize)
-	case leafIndex >= treeSize:
-		return nil, fmt.Errorf("leafIndex is beyond treeSize: %d >= %d", leafIndex, treeSize)
+	case index < 0:
+		return nil, fmt.Errorf("index %d < 0", index)
+	case size < 0:
+		return nil, fmt.Errorf("size %d < 0", size)
+	case index >= size:
+		return nil, fmt.Errorf("index is beyond size: %d >= %d", index, size)
 	}
 	if got, want := len(leafHash), v.hasher.Size(); got != want {
 		return nil, fmt.Errorf("leafHash has unexpected size %d, want %d", got, want)
 	}
 
-	inner, border := decompInclProof(leafIndex, treeSize)
+	inner, border := decompInclProof(index, size)
 	if got, want := len(proof), inner+border; got != want {
 		return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
 	}
 
 	ch := hashChainer(v)
-	res := ch.chainInner(leafHash, proof[:inner], leafIndex)
+	res := ch.chainInner(leafHash, proof[:inner], index)
 	res = ch.chainBorderRight(res, proof[inner:])
 	return res, nil
 }

--- a/log_verifier_test.go
+++ b/log_verifier_test.go
@@ -25,15 +25,15 @@ import (
 )
 
 type inclusionProofTestVector struct {
-	leaf     uint64
-	snapshot uint64
-	proof    [][]byte
+	leaf  uint64
+	size  uint64
+	proof [][]byte
 }
 
 type consistencyTestVector struct {
-	snapshot1 uint64
-	snapshot2 uint64
-	proof     [][]byte
+	size1 uint64
+	size2 uint64
+	proof [][]byte
 }
 
 var (
@@ -117,11 +117,11 @@ type inclusionProbe struct {
 
 // consistencyProbe is a parameter set for consistency proof verification.
 type consistencyProbe struct {
-	snapshot1 uint64
-	snapshot2 uint64
-	root1     []byte
-	root2     []byte
-	proof     [][]byte
+	size1 uint64
+	size2 uint64
+	root1 []byte
+	root2 []byte
+	proof [][]byte
 
 	desc string
 }
@@ -168,36 +168,36 @@ func corruptInclusionProof(leafIndex, treeSize uint64, proof [][]byte, root, lea
 	return ret
 }
 
-func corruptConsistencyProof(snapshot1, snapshot2 uint64, root1, root2 []byte, proof [][]byte) []consistencyProbe {
+func corruptConsistencyProof(size1, size2 uint64, root1, root2 []byte, proof [][]byte) []consistencyProbe {
 	ln := len(proof)
 	ret := []consistencyProbe{
-		// Wrong snapshot index.
-		{snapshot1 - 1, snapshot2, root1, root2, proof, "snapshot1 - 1"},
-		{snapshot1 + 1, snapshot2, root1, root2, proof, "snapshot1 + 1"},
-		{snapshot1 ^ 2, snapshot2, root1, root2, proof, "snapshot1 ^ 2"},
+		// Wrong size1.
+		{size1 - 1, size2, root1, root2, proof, "size1 - 1"},
+		{size1 + 1, size2, root1, root2, proof, "size1 + 1"},
+		{size1 ^ 2, size2, root1, root2, proof, "size1 ^ 2"},
 		// Wrong tree height.
-		{snapshot1, snapshot2 * 2, root1, root2, proof, "snapshot2 * 2"},
-		{snapshot1, snapshot2 / 2, root1, root2, proof, "snapshot2 / 2"},
+		{size1, size2 * 2, root1, root2, proof, "size2 * 2"},
+		{size1, size2 / 2, root1, root2, proof, "size2 / 2"},
 		// Wrong root.
-		{snapshot1, snapshot2, []byte("WrongRoot"), root2, proof, "wrong root1"},
-		{snapshot1, snapshot2, root1, []byte("WrongRoot"), proof, "wrong root2"},
-		{snapshot1, snapshot2, root2, root1, proof, "swapped roots"},
+		{size1, size2, []byte("WrongRoot"), root2, proof, "wrong root1"},
+		{size1, size2, root1, []byte("WrongRoot"), proof, "wrong root2"},
+		{size1, size2, root2, root1, proof, "swapped roots"},
 		// Empty proof.
-		{snapshot1, snapshot2, root1, root2, [][]byte{}, "empty proof"},
+		{size1, size2, root1, root2, [][]byte{}, "empty proof"},
 		// Add garbage at the end.
-		{snapshot1, snapshot2, root1, root2, extend(proof, []byte{}), "trailing garbage"},
-		{snapshot1, snapshot2, root1, root2, extend(proof, root1), "trailing root1"},
-		{snapshot1, snapshot2, root1, root2, extend(proof, root2), "trailing root2"},
+		{size1, size2, root1, root2, extend(proof, []byte{}), "trailing garbage"},
+		{size1, size2, root1, root2, extend(proof, root1), "trailing root1"},
+		{size1, size2, root1, root2, extend(proof, root2), "trailing root2"},
 		// Add garbage at the front.
-		{snapshot1, snapshot2, root1, root2, prepend(proof, []byte{}), "preceding garbage"},
-		{snapshot1, snapshot2, root1, root2, prepend(proof, root1), "preceding root1"},
-		{snapshot1, snapshot2, root1, root2, prepend(proof, root2), "preceding root2"},
-		{snapshot1, snapshot2, root1, root2, prepend(proof, proof[0]), "preceding proof[0]"},
+		{size1, size2, root1, root2, prepend(proof, []byte{}), "preceding garbage"},
+		{size1, size2, root1, root2, prepend(proof, root1), "preceding root1"},
+		{size1, size2, root1, root2, prepend(proof, root2), "preceding root2"},
+		{size1, size2, root1, root2, prepend(proof, proof[0]), "preceding proof[0]"},
 	}
 
 	// Remove a node from the end.
 	if ln > 0 {
-		ret = append(ret, consistencyProbe{snapshot1, snapshot2, root1, root2, proof[:ln-1], "truncated proof"})
+		ret = append(ret, consistencyProbe{size1, size2, root1, root2, proof[:ln-1], "truncated proof"})
 	}
 
 	// Modify single bit in an element of the proof.
@@ -206,7 +206,7 @@ func corruptConsistencyProof(snapshot1, snapshot2 uint64, root1, root2 []byte, p
 		wrongProof[i] = append([]byte(nil), wrongProof[i]...) // But also the modified data.
 		wrongProof[i][0] ^= 16                                // Flip the bit.
 		desc := fmt.Sprintf("modified proof[%d] bit 4", i)
-		ret = append(ret, consistencyProbe{snapshot1, snapshot2, root1, root2, wrongProof, desc})
+		ret = append(ret, consistencyProbe{size1, size2, root1, root2, wrongProof, desc})
 	}
 
 	return ret
@@ -238,21 +238,21 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize uint64, proof [][]byte, r
 	return nil
 }
 
-func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 uint64, root1, root2 []byte, proof [][]byte) error {
+func verifierConsistencyCheck(v *LogVerifier, size1, size2 uint64, root1, root2 []byte, proof [][]byte) error {
 	// Verify original consistency proof.
-	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, root2, proof); err != nil {
+	if err := v.VerifyConsistencyProof(size1, size2, root1, root2, proof); err != nil {
 		return err
 	}
 	// For simplicity test only non-trivial proofs that have root1 != root2,
-	// snapshot1 != 0 and snapshot1 != snapshot2.
+	// size1 != 0 and size1 != size2.
 	if len(proof) == 0 {
 		return nil
 	}
 
-	probes := corruptConsistencyProof(snapshot1, snapshot2, root1, root2, proof)
+	probes := corruptConsistencyProof(size1, size2, root1, root2, proof)
 	var wrong []string
 	for _, p := range probes {
-		if err := v.VerifyConsistencyProof(p.snapshot1, p.snapshot2, p.root1, p.root2, p.proof); err == nil {
+		if err := v.VerifyConsistencyProof(p.size1, p.size2, p.root1, p.root2, p.proof); err == nil {
 			wrong = append(wrong, p.desc)
 		}
 	}
@@ -316,7 +316,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 		p := inclusionProofs[i]
 		t.Run(fmt.Sprintf("proof:%d", i), func(t *testing.T) {
 			leafHash := rfc6962.DefaultHasher.HashLeaf(leaves[p.leaf-1])
-			if err := verifierCheck(&v, p.leaf-1, p.snapshot, p.proof, roots[p.snapshot-1], leafHash); err != nil {
+			if err := verifierCheck(&v, p.leaf-1, p.size, p.proof, roots[p.size-1], leafHash); err != nil {
 				t.Errorf("verifierCheck(): %s", err)
 			}
 		})
@@ -332,14 +332,14 @@ func TestVerifyConsistencyProof(t *testing.T) {
 	proof2 := [][]byte{sha256EmptyTreeHash}
 
 	tests := []struct {
-		snap1, snap2 uint64
+		size1, size2 uint64
 		root1, root2 []byte
 		proof        [][]byte
 		wantErr      bool
 	}{
 		{0, 0, root1, root2, proof1, true},
 		{1, 1, root1, root2, proof1, true},
-		// Snapshots that are always consistent.
+		// Sizes that are always consistent.
 		{0, 0, root1, root1, proof1, false},
 		{0, 1, root1, root2, proof1, false},
 		{1, 1, root2, root2, proof1, false},
@@ -357,8 +357,8 @@ func TestVerifyConsistencyProof(t *testing.T) {
 		{1, 1, sha256EmptyTreeHash, sha256EmptyTreeHash, proof2, true},
 	}
 	for i, p := range tests {
-		t.Run(fmt.Sprintf("test:%d:snap:%d-%d", i, p.snap1, p.snap2), func(t *testing.T) {
-			err := verifierConsistencyCheck(&v, p.snap1, p.snap2, p.root1, p.root2, p.proof)
+		t.Run(fmt.Sprintf("test:%d:size:%d-%d", i, p.size1, p.size2), func(t *testing.T) {
+			err := verifierConsistencyCheck(&v, p.size1, p.size2, p.root1, p.root2, p.proof)
 			if p.wantErr && err == nil {
 				t.Errorf("Incorrectly verified")
 			} else if !p.wantErr && err != nil {
@@ -370,8 +370,8 @@ func TestVerifyConsistencyProof(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		p := consistencyProofs[i]
 		t.Run(fmt.Sprintf("proof:%d", i), func(t *testing.T) {
-			err := verifierConsistencyCheck(&v, p.snapshot1, p.snapshot2,
-				roots[p.snapshot1-1], roots[p.snapshot2-1], p.proof)
+			err := verifierConsistencyCheck(&v, p.size1, p.size2,
+				roots[p.size1-1], roots[p.size2-1], p.proof)
 			if err != nil {
 				t.Fatalf("Failed to verify known good proof: %s", err)
 			}

--- a/log_verifier_test.go
+++ b/log_verifier_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 type inclusionProofTestVector struct {
-	leaf     int64
-	snapshot int64
+	leaf     uint64
+	snapshot uint64
 	proof    [][]byte
 }
 
 type consistencyTestVector struct {
-	snapshot1 int64
-	snapshot2 int64
+	snapshot1 uint64
+	snapshot2 uint64
 	proof     [][]byte
 }
 
@@ -106,8 +106,8 @@ var (
 
 // inclusionProbe is a parameter set for inclusion proof verification.
 type inclusionProbe struct {
-	leafIndex int64
-	treeSize  int64
+	leafIndex uint64
+	treeSize  uint64
 	root      []byte
 	leafHash  []byte
 	proof     [][]byte
@@ -117,8 +117,8 @@ type inclusionProbe struct {
 
 // consistencyProbe is a parameter set for consistency proof verification.
 type consistencyProbe struct {
-	snapshot1 int64
-	snapshot2 int64
+	snapshot1 uint64
+	snapshot2 uint64
 	root1     []byte
 	root2     []byte
 	proof     [][]byte
@@ -126,7 +126,7 @@ type consistencyProbe struct {
 	desc string
 }
 
-func corruptInclusionProof(leafIndex, treeSize int64, proof [][]byte, root, leafHash []byte) []inclusionProbe {
+func corruptInclusionProof(leafIndex, treeSize uint64, proof [][]byte, root, leafHash []byte) []inclusionProbe {
 	ret := []inclusionProbe{
 		// Wrong leaf index.
 		{leafIndex - 1, treeSize, root, leafHash, proof, "leafIndex - 1"},
@@ -168,7 +168,7 @@ func corruptInclusionProof(leafIndex, treeSize int64, proof [][]byte, root, leaf
 	return ret
 }
 
-func corruptConsistencyProof(snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) []consistencyProbe {
+func corruptConsistencyProof(snapshot1, snapshot2 uint64, root1, root2 []byte, proof [][]byte) []consistencyProbe {
 	ln := len(proof)
 	ret := []consistencyProbe{
 		// Wrong snapshot index.
@@ -212,7 +212,7 @@ func corruptConsistencyProof(snapshot1, snapshot2 int64, root1, root2 []byte, pr
 	return ret
 }
 
-func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, root, leafHash []byte) error {
+func verifierCheck(v *LogVerifier, leafIndex, treeSize uint64, proof [][]byte, root, leafHash []byte) error {
 	// Verify original inclusion proof.
 	got, err := v.RootFromInclusionProof(leafIndex, treeSize, proof, leafHash)
 	if err != nil {
@@ -238,7 +238,7 @@ func verifierCheck(v *LogVerifier, leafIndex, treeSize int64, proof [][]byte, ro
 	return nil
 }
 
-func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 int64, root1, root2 []byte, proof [][]byte) error {
+func verifierConsistencyCheck(v *LogVerifier, snapshot1, snapshot2 uint64, root1, root2 []byte, proof [][]byte) error {
 	// Verify original consistency proof.
 	if err := v.VerifyConsistencyProof(snapshot1, snapshot2, root1, root2, proof); err != nil {
 		return err
@@ -295,7 +295,7 @@ func TestVerifyInclusionProof(t *testing.T) {
 	proof := [][]byte{}
 
 	probes := []struct {
-		index, size int64
+		index, size uint64
 	}{{0, 0}, {0, 1}, {1, 0}, {2, 1}}
 	for _, p := range probes {
 		t.Run(fmt.Sprintf("probe:%d:%d", p.index, p.size), func(t *testing.T) {
@@ -332,7 +332,7 @@ func TestVerifyConsistencyProof(t *testing.T) {
 	proof2 := [][]byte{sha256EmptyTreeHash}
 
 	tests := []struct {
-		snap1, snap2 int64
+		snap1, snap2 uint64
 		root1, root2 []byte
 		proof        [][]byte
 		wantErr      bool


### PR DESCRIPTION
- Makes naming more concise and consistent.
- Use `uint64` for tree sizes and leaf indices.

Part of #3.