### PR TITLE
Copy in-memory Merkle tree implementation from Trillian

### DIFF
--- a/compact/range_internal_test.go
+++ b/compact/range_internal_test.go
@@ -1,0 +1,234 @@
+// Copyright 2019 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compact
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	hashChildren = func(_, _ []byte) []byte { return []byte("fake-hash") }
+	factory      = &RangeFactory{Hash: hashChildren}
+)
+
+func TestAppendRangeErrors(t *testing.T) {
+	anotherFactory := &RangeFactory{Hash: hashChildren}
+
+	nonEmpty1, _ := factory.NewRange(7, 8, [][]byte{[]byte("hash")})
+	nonEmpty2, _ := factory.NewRange(0, 6, [][]byte{[]byte("hash0"), []byte("hash1")})
+	nonEmpty3, _ := factory.NewRange(6, 7, [][]byte{[]byte("hash")})
+	corrupt := func(rng *Range, dBegin, dEnd int64) *Range {
+		rng.begin = uint64(int64(rng.begin) + dBegin)
+		rng.end = uint64(int64(rng.end) + dEnd)
+		return rng
+	}
+	for _, tc := range []struct {
+		desc    string
+		l, r    *Range
+		wantErr string
+	}{
+		{
+			desc: "ok",
+			l:    factory.NewEmptyRange(0),
+			r:    factory.NewEmptyRange(0),
+		},
+		{
+			desc:    "incompatible",
+			l:       factory.NewEmptyRange(0),
+			r:       anotherFactory.NewEmptyRange(0),
+			wantErr: "incompatible ranges",
+		},
+		{
+			desc:    "disjoint",
+			l:       factory.NewEmptyRange(0),
+			r:       factory.NewEmptyRange(1),
+			wantErr: "ranges are disjoint",
+		},
+		{
+			desc:    "left_corrupted",
+			l:       corrupt(factory.NewEmptyRange(7), -7, 0),
+			r:       nonEmpty1,
+			wantErr: "corrupted lhs range",
+		},
+		{
+			desc:    "right_corrupted",
+			l:       nonEmpty2,
+			r:       corrupt(nonEmpty3, 0, 20),
+			wantErr: "corrupted rhs range",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.l.AppendRange(tc.r, nil)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("AppendRange: %v; want nil", err)
+				}
+			} else if err == nil || !strings.HasPrefix(err.Error(), tc.wantErr) {
+				t.Fatalf("AppendRange: %v; want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		lhs       *Range
+		rhs       *Range
+		wantEqual bool
+	}{
+		{
+			desc: "incompatible trees",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      &RangeFactory{Hash: hashChildren},
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal begin",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  18,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal end",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    24,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+		},
+
+		{
+			desc: "unequal number of hashes",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1")},
+			},
+		},
+
+		{
+			desc: "mismatched hash",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("not hash 2")},
+			},
+		},
+
+		{
+			desc: "equal ranges",
+			lhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			rhs: &Range{
+				f:      factory,
+				begin:  17,
+				end:    23,
+				hashes: [][]byte{[]byte("hash 1"), []byte("hash 2")},
+			},
+			wantEqual: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if got, want := test.lhs.Equal(test.rhs), test.wantEqual; got != want {
+				t.Errorf("%+v.Equal(%+v) = %v, want %v", test.lhs, test.rhs, got, want)
+			}
+		})
+	}
+}
+
+func TestGetMergePath(t *testing.T) {
+	for _, tc := range []struct {
+		begin, mid, end uint64
+		wantLow         uint
+		wantHigh        uint
+		wantEmpty       bool
+	}{
+		{begin: 0, mid: 0, end: 0, wantEmpty: true},
+		{begin: 0, mid: 0, end: 1, wantEmpty: true},
+		{begin: 0, mid: 0, end: uint64(1) << 63, wantEmpty: true},
+		{begin: 0, mid: 1, end: 1, wantEmpty: true},
+		{begin: 0, mid: 1, end: 2, wantLow: 0, wantHigh: 1},
+		{begin: 0, mid: 16, end: 32, wantLow: 4, wantHigh: 5},
+		{begin: 0, mid: uint64(1) << 63, end: ^uint64(0), wantEmpty: true},
+		{begin: 0, mid: uint64(1) << 63, end: uint64(1)<<63 + 100500, wantEmpty: true},
+		{begin: 2, mid: 9, end: 13, wantLow: 0, wantHigh: 2},
+		{begin: 6, mid: 13, end: 17, wantLow: 0, wantHigh: 3},
+		{begin: 4, mid: 8, end: 16, wantEmpty: true},
+		{begin: 8, mid: 12, end: 16, wantLow: 2, wantHigh: 3},
+		{begin: 4, mid: 6, end: 12, wantLow: 1, wantHigh: 2},
+		{begin: 8, mid: 10, end: 16, wantLow: 1, wantHigh: 3},
+		{begin: 11, mid: 17, end: 27, wantLow: 0, wantHigh: 3},
+		{begin: 11, mid: 16, end: 27, wantEmpty: true},
+	} {
+		t.Run(fmt.Sprintf("%d:%d:%d", tc.begin, tc.mid, tc.end), func(t *testing.T) {
+			low, high := getMergePath(tc.begin, tc.mid, tc.end)
+			if tc.wantEmpty {
+				if low < high {
+					t.Fatalf("getMergePath(%d,%d,%d)=%d,%d; want empty", tc.begin, tc.mid, tc.end, low, high)
+				}
+			} else if low != tc.wantLow || high != tc.wantHigh {
+				t.Fatalf("getMergePath(%d,%d,%d)=%d,%d; want %d,%d", tc.begin, tc.mid, tc.end, low, high, tc.wantLow, tc.wantHigh)
+			}
+		})
+	}
+}

--- a/testonly/constants.go
+++ b/testonly/constants.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package testonly contains code and data for testing Merkle trees.
+// Package testonly contains code and data for testing Merkle trees, such as a
+// reference implementation of in-memory Merkle tree.
 package testonly
 
-import (
-	"encoding/hex"
-)
+import "encoding/hex"
 
 func hd(b string) []byte {
 	r, err := hex.DecodeString(b)

--- a/testonly/reference_test.go
+++ b/testonly/reference_test.go
@@ -1,0 +1,205 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/bits"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/rfc6962"
+)
+
+// The reference Merkle tree hashing and proof algorithms in this file directly
+// implement the definitions from RFC 6962 [1]. We use this implementation only
+// for testing correctness of other more flexible and performant algorithms,
+// such as the in-memory Tree type and compact ranges.
+//
+// [1] https://datatracker.ietf.org/doc/html/rfc6962#section-2
+
+// refRootHash returns the root hash of a Merkle tree with the given entries.
+// This is a reference implementation for cross-checking.
+func refRootHash(entries [][]byte, hasher merkle.LogHasher) []byte {
+	if len(entries) == 0 {
+		return hasher.EmptyRoot()
+	}
+	if len(entries) == 1 {
+		return hasher.HashLeaf(entries[0])
+	}
+	split := downToPowerOfTwo(uint64(len(entries)))
+	return hasher.HashChildren(
+		refRootHash(entries[:split], hasher),
+		refRootHash(entries[split:], hasher))
+}
+
+// refInclusionProof returns the inclusion proof for the given leaf index in a
+// Merkle tree with the given entries. This is a reference implementation for
+// cross-checking.
+func refInclusionProof(entries [][]byte, index uint64, hasher merkle.LogHasher) [][]byte {
+	size := uint64(len(entries))
+	if size == 1 || index >= size {
+		return nil
+	}
+	split := downToPowerOfTwo(size)
+	if index < split {
+		return append(
+			refInclusionProof(entries[:split], index, hasher),
+			refRootHash(entries[split:], hasher))
+	}
+	return append(
+		refInclusionProof(entries[split:], index-split, hasher),
+		refRootHash(entries[:split], hasher))
+}
+
+// refConsistencyProof returns the consistency proof for the two tree sizes, in
+// a Merkle tree with the given entries. This is a reference implementation for
+// cross-checking.
+func refConsistencyProof(entries [][]byte, size2, size1 uint64, hasher merkle.LogHasher, haveRoot1 bool) [][]byte {
+	if size1 == 0 || size1 > size2 {
+		return nil
+	}
+	// Consistency proof for two equal sizes is empty.
+	if size1 == size2 {
+		// Record the hash of this subtree if it's not the root for which the proof
+		// was originally requested (which happens when size1 is a power of 2).
+		if !haveRoot1 {
+			return [][]byte{refRootHash(entries[:size1], hasher)}
+		}
+		return nil
+	}
+
+	// At this point: 0 < size1 < size2.
+	split := downToPowerOfTwo(size2)
+	if size1 <= split {
+		// Root of size1 is in the left subtree of size2. Prove that the left
+		// subtrees are consistent, and record the hash of the right subtree (only
+		// present in size2).
+		return append(
+			refConsistencyProof(entries[:split], split, size1, hasher, haveRoot1),
+			refRootHash(entries[split:], hasher))
+	}
+
+	// Root of size1 is at the same level as size2 root. Prove that the right
+	// subtrees are consistent. The right subtree doesn't contain the root of
+	// size1, so set haveRoot1 = false. Record the hash of the left subtree
+	// (equal in both trees).
+	return append(
+		refConsistencyProof(entries[split:], size2-split, size1-split, hasher, false),
+		refRootHash(entries[:split], hasher))
+}
+
+// downToPowerOfTwo returns the largest power of two smaller than x.
+func downToPowerOfTwo(x uint64) uint64 {
+	if x < 2 {
+		panic("downToPowerOfTwo requires value >= 2")
+	}
+	return uint64(1) << (bits.Len64(x-1) - 1)
+}
+
+func TestDownToPowerOfTwo(t *testing.T) {
+	for _, inOut := range [][2]uint64{
+		{2, 1}, {7, 4}, {8, 4}, {63, 32}, {28937, 16384},
+	} {
+		if got, want := downToPowerOfTwo(inOut[0]), inOut[1]; got != want {
+			t.Errorf("downToPowerOfTwo(%d): got %d, want %d", inOut[0], got, want)
+		}
+	}
+}
+
+func TestRefInclusionProof(t *testing.T) {
+	for _, tc := range []struct {
+		index uint64
+		size  uint64
+		want  [][]byte
+	}{
+		{index: 0, size: 1, want: nil},
+		{index: 0, size: 2, want: [][]byte{
+			hx("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"),
+		}},
+		{index: 1, size: 2, want: [][]byte{
+			hx("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
+		}},
+		{index: 2, size: 3, want: [][]byte{
+			hx("fac54203e7cc696cf0dfcb42c92a1d9dbaf70ad9e621f4bd8d98662f00e3c125"),
+		}},
+		{index: 1, size: 5, want: [][]byte{
+			hx("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"),
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"),
+		}},
+		{index: 0, size: 8, want: [][]byte{
+			hx("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"),
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"),
+		}},
+		{index: 5, size: 8, want: [][]byte{
+			hx("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"),
+			hx("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"),
+			hx("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
+		}},
+	} {
+		t.Run(fmt.Sprintf("%d:%d", tc.index, tc.size), func(t *testing.T) {
+			entries := LeafInputs()
+			got := refInclusionProof(entries[:tc.size], tc.index, rfc6962.DefaultHasher)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("refInclusionProof: diff (-got +want)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRefConsistencyProof(t *testing.T) {
+	for _, tc := range []struct {
+		size1 uint64
+		size2 uint64
+		want  [][]byte
+	}{
+		{size1: 1, size2: 1, want: nil},
+		{size1: 1, size2: 8, want: [][]byte{
+			hx("96a296d224f285c67bee93c30f8a309157f0daa35dc5b87e410b78630a09cfc7"),
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("6b47aaf29ee3c2af9af889bc1fb9254dabd31177f16232dd6aab035ca39bf6e4"),
+		}},
+		{size1: 2, size2: 5, want: [][]byte{
+			hx("5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e"),
+			hx("bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b"),
+		}},
+		{size1: 6, size2: 8, want: [][]byte{
+			hx("0ebc5d3437fbe2db158b9f126a1d118e308181031d0a949f8dededebc558ef6a"),
+			hx("ca854ea128ed050b41b35ffc1b87b8eb2bde461e9e3b5596ece6b9d5975a0ae0"),
+			hx("d37ee418976dd95753c1c73862b9398fa2a2cf9b4ff0fdfe8b30cd95209614b7"),
+		}},
+	} {
+		t.Run(fmt.Sprintf("%d:%d", tc.size1, tc.size2), func(t *testing.T) {
+			entries := LeafInputs()
+			got := refConsistencyProof(entries[:tc.size2], tc.size2, tc.size1, rfc6962.DefaultHasher, true)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("refConsistencyProof: diff (-got +want)\n%s", diff)
+			}
+		})
+	}
+}
+
+// hx decodes a hex string or panics.
+func hx(hs string) []byte {
+	data, err := hex.DecodeString(hs)
+	if err != nil {
+		panic(fmt.Errorf("failed to decode test data: %s", hs))
+	}
+	return data
+}

--- a/testonly/tree.go
+++ b/testonly/tree.go
@@ -1,0 +1,124 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/proof"
+)
+
+// Tree implements an append-only Merkle tree. For testing.
+type Tree struct {
+	hasher merkle.LogHasher
+	size   uint64
+	hashes [][][]byte // Node hashes, indexed by node (level, index).
+}
+
+// New returns a new empty Merkle tree.
+func New(hasher merkle.LogHasher) *Tree {
+	return &Tree{hasher: hasher}
+}
+
+// AppendData adds the leaf hashes of the given entries to the end of the tree.
+func (t *Tree) AppendData(entries ...[]byte) {
+	for _, data := range entries {
+		t.appendImpl(t.hasher.HashLeaf(data))
+	}
+}
+
+// Append adds the given leaf hashes to the end of the tree.
+func (t *Tree) Append(hashes ...[]byte) {
+	for _, hash := range hashes {
+		t.appendImpl(hash)
+	}
+}
+
+func (t *Tree) appendImpl(hash []byte) {
+	level := 0
+	for ; (t.size>>level)&1 == 1; level++ {
+		row := append(t.hashes[level], hash)
+		hash = t.hasher.HashChildren(row[len(row)-2], hash)
+		t.hashes[level] = row
+	}
+	if level > len(t.hashes) {
+		panic("gap in tree appends")
+	} else if level == len(t.hashes) {
+		t.hashes = append(t.hashes, nil)
+	}
+
+	t.hashes[level] = append(t.hashes[level], hash)
+	t.size++
+}
+
+// Size returns the current number of leaves in the tree.
+func (t *Tree) Size() uint64 {
+	return t.size
+}
+
+// LeafHash returns the leaf hash at the given index.
+// Requires 0 <= index < Size(), otherwise panics.
+func (t *Tree) LeafHash(index uint64) []byte {
+	return t.hashes[0][index]
+}
+
+// Hash returns the current root hash of the tree.
+func (t *Tree) Hash() []byte {
+	return t.HashAt(t.size)
+}
+
+// HashAt returns the root hash at the given size.
+// Requires 0 <= size <= Size(), otherwise panics.
+func (t *Tree) HashAt(size uint64) []byte {
+	if size == 0 {
+		return t.hasher.EmptyRoot()
+	}
+	hashes := t.getNodes(compact.RangeNodes(0, size, nil))
+
+	hash := hashes[len(hashes)-1]
+	for i := len(hashes) - 2; i >= 0; i-- {
+		hash = t.hasher.HashChildren(hashes[i], hash)
+	}
+	return hash
+}
+
+// InclusionProof returns the inclusion proof for the given leaf index in the
+// tree of the given size. Requires 0 <= index < size <= Size(), otherwise may
+// panic.
+func (t *Tree) InclusionProof(index, size uint64) ([][]byte, error) {
+	nodes, err := proof.Inclusion(index, size)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Rehash(t.getNodes(nodes.IDs), t.hasher.HashChildren)
+}
+
+// ConsistencyProof returns the consistency proof between the two given tree
+// sizes. Requires 0 <= size1 <= size2 <= Size(), otherwise may panic.
+func (t *Tree) ConsistencyProof(size1, size2 uint64) ([][]byte, error) {
+	nodes, err := proof.Consistency(size1, size2)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Rehash(t.getNodes(nodes.IDs), t.hasher.HashChildren)
+}
+
+func (t *Tree) getNodes(ids []compact.NodeID) [][]byte {
+	hashes := make([][]byte, len(ids))
+	for i, id := range ids {
+		hashes[i] = t.hashes[id.Level][id.Index]
+	}
+	return hashes
+}

--- a/testonly/tree_test.go
+++ b/testonly/tree_test.go
@@ -1,0 +1,203 @@
+// Copyright 2022 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testonly
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/transparency-dev/merkle/rfc6962"
+)
+
+func validateTree(t *testing.T, mt *Tree, size uint64) {
+	t.Helper()
+	if got, want := mt.Size(), size; got != want {
+		t.Errorf("Size: %d, want %d", got, want)
+	}
+	roots := RootHashes()
+	if got, want := mt.Hash(), roots[size]; !bytes.Equal(got, want) {
+		t.Errorf("Hash(%d): %x, want %x", size, got, want)
+	}
+	for s := uint64(0); s <= size; s++ {
+		if got, want := mt.HashAt(s), roots[s]; !bytes.Equal(got, want) {
+			t.Errorf("HashAt(%d/%d): %x, want %x", s, size, got, want)
+		}
+	}
+}
+
+func TestBuildTreeBuildOneAtATime(t *testing.T) {
+	mt := newTree(nil)
+	validateTree(t, mt, 0)
+	for i, entry := range LeafInputs() {
+		mt.AppendData(entry)
+		validateTree(t, mt, uint64(i+1))
+	}
+}
+
+func TestBuildTreeBuildTwoChunks(t *testing.T) {
+	entries := LeafInputs()
+	mt := newTree(nil)
+	mt.AppendData(entries[:3]...)
+	validateTree(t, mt, 3)
+	mt.AppendData(entries[3:8]...)
+	validateTree(t, mt, 8)
+}
+
+func TestBuildTreeBuildAllAtOnce(t *testing.T) {
+	mt := newTree(nil)
+	mt.AppendData(LeafInputs()...)
+	validateTree(t, mt, 8)
+}
+
+func TestTreeHashAt(t *testing.T) {
+	test := func(desc string, entries [][]byte) {
+		t.Run(desc, func(t *testing.T) {
+			mt := newTree(entries)
+			for size := 0; size <= len(entries); size++ {
+				got := mt.HashAt(uint64(size))
+				want := refRootHash(entries[:size], mt.hasher)
+				if !bytes.Equal(got, want) {
+					t.Errorf("HashAt(%d): %x, want %x", size, got, want)
+				}
+			}
+		})
+	}
+
+	entries := LeafInputs()
+	for size := 0; size <= len(entries); size++ {
+		test(fmt.Sprintf("size:%d", size), entries[:size])
+	}
+	test("generated", genEntries(256))
+}
+
+func TestTreeInclusionProof(t *testing.T) {
+	test := func(desc string, entries [][]byte) {
+		t.Run(desc, func(t *testing.T) {
+			mt := newTree(entries)
+			for index, size := uint64(0), uint64(len(entries)); index < size; index++ {
+				got, err := mt.InclusionProof(index, size)
+				if err != nil {
+					t.Fatalf("InclusionProof(%d, %d): %v", index, size, err)
+				}
+				want := refInclusionProof(entries[:size], index, mt.hasher)
+				if diff := cmp.Diff(got, want, cmpopts.EquateEmpty()); diff != "" {
+					t.Fatalf("InclusionProof(%d, %d): diff (-got +want)\n%s", index, size, diff)
+				}
+			}
+		})
+	}
+
+	test("generated", genEntries(256))
+	entries := LeafInputs()
+	for size := 0; size < len(entries); size++ {
+		test(fmt.Sprintf("golden:%d", size), entries[:size])
+	}
+}
+
+func TestTreeConsistencyProof(t *testing.T) {
+	entries := LeafInputs()
+	mt := newTree(entries)
+	validateTree(t, mt, 8)
+
+	if _, err := mt.ConsistencyProof(6, 3); err == nil {
+		t.Error("ConsistencyProof(6, 3) succeeded unexpectedly")
+	}
+
+	for size1 := uint64(0); size1 <= 8; size1++ {
+		for size2 := size1; size2 <= 8; size2++ {
+			t.Run(fmt.Sprintf("%d:%d", size1, size2), func(t *testing.T) {
+				got, err := mt.ConsistencyProof(size1, size2)
+				if err != nil {
+					t.Fatalf("ConsistencyProof: %v", err)
+				}
+				want := refConsistencyProof(entries[:size2], size2, size1, mt.hasher, true)
+				if diff := cmp.Diff(got, want, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("ConsistencyProof: diff (-got +want)\n%s", diff)
+				}
+			})
+		}
+	}
+}
+
+// Make random proof queries and check against the reference implementation.
+func TestTreeConsistencyProofFuzz(t *testing.T) {
+	entries := genEntries(256)
+
+	for treeSize := int64(1); treeSize <= 256; treeSize++ {
+		mt := newTree(entries[:treeSize])
+		for i := 0; i < 8; i++ {
+			size2 := uint64(rand.Int63n(treeSize + 1))
+			size1 := uint64(rand.Int63n(int64(size2) + 1))
+
+			got, err := mt.ConsistencyProof(size1, size2)
+			if err != nil {
+				t.Fatalf("ConsistencyProof: %v", err)
+			}
+			want := refConsistencyProof(entries[:size2], size2, size1, mt.hasher, true)
+			if diff := cmp.Diff(got, want, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("ConsistencyProof: diff (-got +want)\n%s", diff)
+			}
+		}
+	}
+}
+
+func TestTreeAppend(t *testing.T) {
+	entries := genEntries(256)
+	mt1 := newTree(entries)
+
+	mt2 := newTree(nil)
+	for _, entry := range entries {
+		mt2.Append(rfc6962.DefaultHasher.HashLeaf(entry))
+	}
+
+	if diff := cmp.Diff(mt1, mt2, cmp.AllowUnexported(Tree{})); diff != "" {
+		t.Errorf("Trees built with AppendData and Append mismatch: diff (-mt1 +mt2)\n%s", diff)
+	}
+}
+
+func TestTreeAppendAssociativity(t *testing.T) {
+	entries := genEntries(256)
+	mt1 := newTree(nil)
+	mt1.AppendData(entries...)
+
+	mt2 := newTree(nil)
+	for _, entry := range entries {
+		mt2.AppendData(entry)
+	}
+
+	if diff := cmp.Diff(mt1, mt2, cmp.AllowUnexported(Tree{})); diff != "" {
+		t.Errorf("AppendData is not associative: diff (-mt1 +mt2)\n%s", diff)
+	}
+}
+
+func newTree(entries [][]byte) *Tree {
+	tree := New(rfc6962.DefaultHasher)
+	tree.AppendData(entries...)
+	return tree
+}
+
+// genEntries a slice of entries of the given size.
+func genEntries(size uint64) [][]byte {
+	entries := make([][]byte, size)
+	for i := range entries {
+		entries[i] = []byte(strconv.Itoa(i))
+	}
+	return entries
+}


### PR DESCRIPTION
This is a port of in-memory Merkle tree from Trillian. This implementation
will be used both in `merkle` and `trillian` for testing, and can be used by
other packages that need a reference Merkle tree for their tests.

Next steps are:
- Remove this code from Trillian.
- Refactor boilerplate in `merkle` tests which duplicates `testonly.Tree`,
such as in tests for `compact`.