### PR TITLE
proof: Avoid all reallocations

### DIFF
--- a/compact/nodes.go
+++ b/compact/nodes.go
@@ -56,10 +56,11 @@ func (id NodeID) Coverage() (uint64, uint64) {
 	return id.Index << id.Level, (id.Index + 1) << id.Level
 }
 
-// RangeNodes returns node IDs that comprise the [begin, end) compact range.
-func RangeNodes(begin, end uint64) []NodeID {
+// RangeNodes appends the IDs of the nodes that comprise the [begin, end)
+// compact range to the given slice, and returns the new slice. The caller may
+// pre-allocate space with the help of the RangeSize function.
+func RangeNodes(begin, end uint64, ids []NodeID) []NodeID {
 	left, right := Decompose(begin, end)
-	ids := make([]NodeID, 0, bits.OnesCount64(left)+bits.OnesCount64(right))
 
 	pos := begin
 	// Iterate over perfect subtrees along the left border of the range, ordered
@@ -79,4 +80,10 @@ func RangeNodes(begin, end uint64) []NodeID {
 	}
 
 	return ids
+}
+
+// RangeSize returns the number of nodes in the [begin, end) compact range.
+func RangeSize(begin, end uint64) int {
+	left, right := Decompose(begin, end)
+	return bits.OnesCount64(left) + bits.OnesCount64(right)
 }

--- a/compact/nodes_test.go
+++ b/compact/nodes_test.go
@@ -78,6 +78,19 @@ func TestRangeNodesAndSize(t *testing.T) {
 	}
 }
 
+func TestRangeNodesAppend(t *testing.T) {
+	prefix := []NodeID{NewNodeID(0, 0), NewNodeID(10, 0), NewNodeID(11, 5)}
+	nodes := RangeNodes(123, 456, prefix)
+
+	if got, min := len(nodes), len(prefix); got < min {
+		t.Fatalf("RangeNodes returned %d IDs, want >= %d", got, min)
+	}
+	got := nodes[:len(prefix)]
+	if diff := cmp.Diff(got, prefix); diff != "" {
+		t.Fatalf("RangeNodes: diff(-prefix +got):\n%s", diff)
+	}
+}
+
 func TestGenRangeNodes(t *testing.T) {
 	const size = uint64(512)
 	for begin := uint64(0); begin <= size; begin++ {

--- a/compact/range.go
+++ b/compact/range.go
@@ -41,10 +41,8 @@ func (f *RangeFactory) NewRange(begin, end uint64, hashes [][]byte) (*Range, err
 	if end < begin {
 		return nil, fmt.Errorf("invalid range: end=%d, want >= %d", end, begin)
 	}
-	left, right := Decompose(begin, end)
-	ones := bits.OnesCount64(left) + bits.OnesCount64(right)
-	if ln := len(hashes); ln != ones {
-		return nil, fmt.Errorf("invalid hashes: got %d values, want %d", ln, ones)
+	if got, want := len(hashes), RangeSize(begin, end); got != want {
+		return nil, fmt.Errorf("invalid hashes: got %d values, want %d", got, want)
 	}
 	return &Range{f: f, begin: begin, end: end, hashes: hashes}, nil
 }

--- a/compact/range_test.go
+++ b/compact/range_test.go
@@ -368,7 +368,7 @@ func TestNewRangeWithStorage(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("%d: Append: %v", i, err)
 		}
-		hashes := getHashes(RangeNodes(0, i+1))
+		hashes := getHashes(RangeNodes(0, i+1, nil))
 		var err error
 		if cr, err = factory.NewRange(0, i+1, hashes); err != nil {
 			t.Fatalf("%d: NewRange: %v", i+1, err)


### PR DESCRIPTION
This change introduces pre-allocation into the `Proof` generation types, thereby
reducing the total number of slice allocations to one. A new helper for computing
the compact range size `compact.RangeSize` is introduced, and the signature of
the previous `compact.RangeNodes` now requires providing a slice to append the
result to.

Part of #3.