### PR TITLE
Added lint configuration and fixed error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,34 @@
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 90s
+
+linters-settings:
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 25
+  depguard:
+    list-type: blacklist
+    packages:
+      - golang.org/x/net/context
+      - github.com/gogo/protobuf/proto
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - depguard
+    - gocyclo
+    - gofmt
+    - goimports
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - revive
+    - varcheck
+    # TODO(gbelvin): write license linter and commit to upstream.
+    # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
+
+issues:
+  # Don't turn off any checks by default. We can do this explicitly if needed.
+  exclude-use-default: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,8 +26,6 @@ linters:
     - misspell
     - revive
     - varcheck
-    # TODO(gbelvin): write license linter and commit to upstream.
-    # ./scripts/check_license.sh is run by ./scripts/presubmit.sh
 
 issues:
   # Don't turn off any checks by default. We can do this explicitly if needed.

--- a/proof/verify_test.go
+++ b/proof/verify_test.go
@@ -403,10 +403,3 @@ func dh(h string, expLen int) []byte {
 	}
 	return r
 }
-
-func shortHash(hash []byte) string {
-	if len(hash) == 0 {
-		return "<empty>"
-	}
-	return fmt.Sprintf("%x...", hash[:4])
-}


### PR DESCRIPTION
Will try to set up presubmit integration in subsequent PR.
For now, `golangci-lint run` at least passes locally, which is
still an improvement from before this PR.
