### PR TITLE
Update to go1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/transparency-dev/merkle
 
-go 1.16
+go 1.17
 
 require github.com/google/go-cmp v0.5.6
+
+require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect


### PR DESCRIPTION
We _may_ want to go further than this to support fuzzing (#33), but as an interim go1.17 is sufficiently old that I don't think we'll be excluding anyone by bumping to this.
