### PR TITLE
Added generated seeds for FuzzRangeNodes

### DIFF
--- a/compact/testdata/fuzz/FuzzRangeNodes/03167a8f4de6b14a237e918bd96fea8dd45076bd458c8bcf96b09a61df6846ae
+++ b/compact/testdata/fuzz/FuzzRangeNodes/03167a8f4de6b14a237e918bd96fea8dd45076bd458c8bcf96b09a61df6846ae
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(1)
+uint64(6)

--- a/compact/testdata/fuzz/FuzzRangeNodes/0e0f7b76aefbacfec1b9d14fb1cf6ddfccbe6772ff60f2ba617fb1b7884df19f
+++ b/compact/testdata/fuzz/FuzzRangeNodes/0e0f7b76aefbacfec1b9d14fb1cf6ddfccbe6772ff60f2ba617fb1b7884df19f
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(60)
+uint64(68)

--- a/compact/testdata/fuzz/FuzzRangeNodes/13cdadf28017adae88657be24090473325f4db10ab8fa3f22541b7cb10b683b1
+++ b/compact/testdata/fuzz/FuzzRangeNodes/13cdadf28017adae88657be24090473325f4db10ab8fa3f22541b7cb10b683b1
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(97)
+uint64(511)

--- a/compact/testdata/fuzz/FuzzRangeNodes/13dddce380497392cc2a016ad6b881063b6bd99abfd4ffca8ce2781524e43a44
+++ b/compact/testdata/fuzz/FuzzRangeNodes/13dddce380497392cc2a016ad6b881063b6bd99abfd4ffca8ce2781524e43a44
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(0)
+uint64(75)

--- a/compact/testdata/fuzz/FuzzRangeNodes/2d382dbaf5238a4066cd46a22d5e3d37deeefd23087f7b46aa0352efe2de13a1
+++ b/compact/testdata/fuzz/FuzzRangeNodes/2d382dbaf5238a4066cd46a22d5e3d37deeefd23087f7b46aa0352efe2de13a1
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(63)
+uint64(110)

--- a/compact/testdata/fuzz/FuzzRangeNodes/2e26d182e06aac76b42a5fa546fa288652501b7a8384489e7d2ebbe43290b8b2
+++ b/compact/testdata/fuzz/FuzzRangeNodes/2e26d182e06aac76b42a5fa546fa288652501b7a8384489e7d2ebbe43290b8b2
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(34)
+uint64(221)

--- a/compact/testdata/fuzz/FuzzRangeNodes/4502438e2e714833404e371f4ccdffdb472d8ece05d9cd70685d4911671d73a5
+++ b/compact/testdata/fuzz/FuzzRangeNodes/4502438e2e714833404e371f4ccdffdb472d8ece05d9cd70685d4911671d73a5
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(0)
+uint64(52)

--- a/compact/testdata/fuzz/FuzzRangeNodes/4b5b8deb6dc0a2aabf73efc8f107f9241a5504cc069224dc666bc2d5ab576f58
+++ b/compact/testdata/fuzz/FuzzRangeNodes/4b5b8deb6dc0a2aabf73efc8f107f9241a5504cc069224dc666bc2d5ab576f58
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(3)
+uint64(3)

--- a/compact/testdata/fuzz/FuzzRangeNodes/629ea6f8a4d39bad9b1d45832a75a9b5d81814269fa9ca20e9f9c77e83d78548
+++ b/compact/testdata/fuzz/FuzzRangeNodes/629ea6f8a4d39bad9b1d45832a75a9b5d81814269fa9ca20e9f9c77e83d78548
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(5)
+uint64(507)

--- a/compact/testdata/fuzz/FuzzRangeNodes/6365559667f7be67023423270b88fa3cbeb746c81f784f15382a2f66f3a6a151
+++ b/compact/testdata/fuzz/FuzzRangeNodes/6365559667f7be67023423270b88fa3cbeb746c81f784f15382a2f66f3a6a151
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(71)
+uint64(0)

--- a/compact/testdata/fuzz/FuzzRangeNodes/74bfce2710370711bdd53cb9450cb8b84b542b6c0a04b6a02e0cbbdb49e6888e
+++ b/compact/testdata/fuzz/FuzzRangeNodes/74bfce2710370711bdd53cb9450cb8b84b542b6c0a04b6a02e0cbbdb49e6888e
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(81)
+uint64(82)

--- a/compact/testdata/fuzz/FuzzRangeNodes/8196e8e5d77a138305dac92e1dae4e651c5da36949f7f9164e26d07d7372bc28
+++ b/compact/testdata/fuzz/FuzzRangeNodes/8196e8e5d77a138305dac92e1dae4e651c5da36949f7f9164e26d07d7372bc28
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(179)
+uint64(255)

--- a/compact/testdata/fuzz/FuzzRangeNodes/88904c8350b849ec832a6b9b5a891c5cbb856afa6d3b9c165ec0c8a011292734
+++ b/compact/testdata/fuzz/FuzzRangeNodes/88904c8350b849ec832a6b9b5a891c5cbb856afa6d3b9c165ec0c8a011292734
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(1)
+uint64(767)

--- a/compact/testdata/fuzz/FuzzRangeNodes/b05a02e2727c643c61be18ef3d80944cceec0e779ee8377dfea4e4e47c2d9d48
+++ b/compact/testdata/fuzz/FuzzRangeNodes/b05a02e2727c643c61be18ef3d80944cceec0e779ee8377dfea4e4e47c2d9d48
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(1)
+uint64(511)

--- a/compact/testdata/fuzz/FuzzRangeNodes/b73cd67a4c77db1aaab5159c2eee5dff74a80e26067a27cfb95832eb0efbf060
+++ b/compact/testdata/fuzz/FuzzRangeNodes/b73cd67a4c77db1aaab5159c2eee5dff74a80e26067a27cfb95832eb0efbf060
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(1)
+uint64(311)

--- a/compact/testdata/fuzz/FuzzRangeNodes/d92b8ab319960fa968031e6f81ab556df172f913181333c528e98c6ad436578a
+++ b/compact/testdata/fuzz/FuzzRangeNodes/d92b8ab319960fa968031e6f81ab556df172f913181333c528e98c6ad436578a
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(71)
+uint64(95)

--- a/compact/testdata/fuzz/FuzzRangeNodes/e32129a7a793ab12790555c46d5a0fb4accddacf1cab7e9bbabca02d71cbbdb7
+++ b/compact/testdata/fuzz/FuzzRangeNodes/e32129a7a793ab12790555c46d5a0fb4accddacf1cab7e9bbabca02d71cbbdb7
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(0)
+uint64(3)

--- a/compact/testdata/fuzz/FuzzRangeNodes/e7b6d88b27442e32ccc06572bb36c824c03427ec1d5dd721b485612f3b55b1ec
+++ b/compact/testdata/fuzz/FuzzRangeNodes/e7b6d88b27442e32ccc06572bb36c824c03427ec1d5dd721b485612f3b55b1ec
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(13)
+uint64(79)

--- a/compact/testdata/fuzz/FuzzRangeNodes/e8813e9a7cebcf576a05697f95cff9b1f2dfaecf3969ccccec84582165d2747d
+++ b/compact/testdata/fuzz/FuzzRangeNodes/e8813e9a7cebcf576a05697f95cff9b1f2dfaecf3969ccccec84582165d2747d
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint64(13)
+uint64(351)


### PR DESCRIPTION
Reading and extrapolating from https://go.dev/doc/fuzz/, the Fuzz test will only be fully exercised when a single Fuzz test is run explicitly with the -fuzz parameter to go test. When running go test without this, the Fuzz test will be invoked, but only on the seed corpus. As FuzzRangeNodes did not have a seed corpus, then this test is effectively skipped in our presubmits and CI pipeline.

This change adds the generated corpus from running the fuzz test as the seed corpus. This shouldn't change how well the test is covered when the -fuzz parameter is provided, but does mean that the test will be exercised as part of CI. This seems like a win, but maybe it's bonkers to be submitting generated files?

The generated corpus was acquired with the following commands:
```
go test --fuzz=FuzzRangeNodes --fuzztime=20s ./compact
mkdir -p compact/testdata/fuzz
cp -R `go env GOCACHE`/fuzz/github.com/transparency-dev/merkle/compact/FuzzRangeNodes compact/testdata/fuzz
```