### PR TITLE
ClusterFuzzLite integration and GitHub Actions

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/merkle
+WORKDIR merkle
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,5 @@
+# https://google.github.io/clusterfuzzlite/build-integration/#dockerfile
 FROM gcr.io/oss-fuzz-base/base-builder-go
 COPY . $SRC/merkle
-WORKDIR merkle
+WORKDIR $SRC/merkle
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,2 @@
+go get github.com/AdamKorcz/go-118-fuzz-build/utils
+compile_native_go_fuzzer github.com/transparency-dev/merkle/compact FuzzRangeNodes FuzzRangeNodes

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,2 +1,6 @@
+# https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#buildsh
+# undocumented dependency
+go install github.com/AdamKorcz/go-118-fuzz-build@latest
 go get github.com/AdamKorcz/go-118-fuzz-build/utils
+# necessary to list each fuzz test explicitly
 compile_native_go_fuzzer github.com/transparency-dev/merkle/compact FuzzRangeNodes FuzzRangeNodes

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,5 @@
+language: go
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,3 +1,4 @@
+# https://google.github.io/clusterfuzzlite//build-integration/go-lang/
 language: go
 fuzzing_engines:
   - libfuzzer

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,28 @@
+name: ClusterFuzzLite continuous builds
+on:
+  push:
+    branches:
+      - main  # Use your actual default branch here.
+permissions: read-all
+jobs:
+  Build:
+   runs-on: ubuntu-latest
+   concurrency:
+     group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+     cancel-in-progress: true
+   strategy:
+     fail-fast: false
+     matrix:
+        sanitizer:
+        - address
+        # Override this with the sanitizers you want.
+        # - undefined
+        # - memory
+   steps:
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
+     id: build
+     uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+     with:
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+        upload-build: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,48 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        # Override this with the sanitizers you want.
+        # - undefined
+        # - memory
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: go
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to only run fuzzers that are affected
+        # by the PR.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 600
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to download the corpus produced by
+        # batch fuzzing.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".


### PR DESCRIPTION
> [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is a continuous fuzzing solution that runs as part of Continuous Integration (CI) workflows to find vulnerabilities faster than ever before. With just a few lines of code, **GitHub users can integrate ClusterFuzzLite into their workflow and fuzz pull requests to catch bugs before they are committed**.

Following https://google.github.io/clusterfuzzlite/build-integration/ with bits of https://google.github.io/oss-fuzz/getting-started/new-project-guide/go-lang/#native-go-fuzzing-support

Tested:
    
    git clone https://github.com/google/oss-fuzz.git
    export PATH_TO_PROJECT=$HOME/merkle
    python3 infra/helper.py build_image --external $PATH_TO_PROJECT
    sudo python3 infra/helper.py build_fuzzers --external $PATH_TO_PROJECT
    sudo python3 infra/helper.py run_fuzzer --external $PATH_TO_PROJECT FuzzRangeNodes

Setup for [OSS-Fuzz](https://google.github.io/oss-fuzz/) (runs on Google infrastructure rather than GitHub Actions) would be similar.