### PR TITLE
Tighten action permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '37 3 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Test Go
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Explicitly mark CodeQL and go_test as read-only.