### PR TITLE
Update dependabot weekly instead of daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       patterns:
         - "*"
   schedule:
-    interval: daily
+    interval: weekly
   commit-message:
     prefix: ":seedling:"
     include: "scope"
@@ -19,7 +19,7 @@ updates:
       patterns:
         - "*"
   schedule:
-    interval: daily
+    interval: weekly
   commit-message:
     prefix: ":seedling:"
     include: "scope"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@dd0578b371c987f96d1185abb54344b44352bd58 # v1.0.3
         with:
-          go-version-input: 1.20.8
+          go-version-input: 1.21.11
           go-package: ./...


### PR DESCRIPTION
Also bump version of go used by vulnerability scanner
