### PR TITLE
Update token used for scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,7 +45,9 @@ jobs:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecards on a *private* repository
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # TODO(mhutchinson): Instead of this, we should use rulesets and then permissions are not needed:
+          # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets
+          repo_token: ${{ secrets.TD_SCORECARD_READ_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers


### PR DESCRIPTION
This was previously using a github secret that was per-repo. I've switched it over to an org-level secret, which should allow us to avoid copying and pasting the secret around a number of times. Added a note that we should switch over to branch protection rulesets instead, which should mean that this read permission isn't needed at all.

Motivation is that the original token is expiring within the week.
