### PR TITLE
Support calculating root from consistency proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+* Breaking change: consistency proofs from `size1 = 0` to `size2 != 0` now always fail
+  * Previously, this could succeed if the empty proof was provided
 * Bump Go version from 1.19 to 1.20
 
 ## v0.0.2

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -74,7 +74,7 @@ func RootFromInclusionProof(hasher merkle.LogHasher, index, size uint64, leafHas
 
 // VerifyConsistency checks that the passed-in consistency proof is valid
 // between the passed in tree sizes, with respect to the corresponding root
-// hashes. Requires 0 <= size1 <= size2.
+// hashes. Requires 0 < size1 <= size2.
 func VerifyConsistency(hasher merkle.LogHasher, size1, size2 uint64, proof [][]byte, root1, root2 []byte) error {
 	hash2, err := RootFromConsistencyProof(hasher, size1, size2, proof, root1)
 	if err != nil {
@@ -83,6 +83,10 @@ func VerifyConsistency(hasher merkle.LogHasher, size1, size2 uint64, proof [][]b
 	return verifyMatch(hash2, root2)
 }
 
+// RootFromConsistencyProof calculates the expected root hash for a tree of the
+// given size2, provided a tree of size1 with root1, and a consistency proof.
+// Requires 0 < size1 <= size2.
+// Note that consistency proofs from a size1==0 cannot be computed.
 func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proof [][]byte, root1 []byte) ([]byte, error) {
 	switch {
 	case size2 < size1:
@@ -93,7 +97,7 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 		}
 		return root1, nil
 	case size1 == 0:
-		return nil, errors.New("Consistency proof from empty tree are meaningless")
+		return nil, errors.New("consistency proof from empty tree is meaningless")
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}

--- a/proof/verify_test.go
+++ b/proof/verify_test.go
@@ -344,7 +344,7 @@ func TestVerifyConsistency(t *testing.T) {
 		{1, 1, root1, root2, proof1, true},
 		// Sizes that are always consistent.
 		{0, 0, root1, root1, proof1, false},
-		{0, 1, root1, root2, proof1, false},
+		{0, 1, root1, root2, proof1, true},
 		{1, 1, root2, root2, proof1, false},
 		// Time travel to the past.
 		{1, 0, root1, root2, proof1, true},

--- a/testonly/tree_fuzz_test.go
+++ b/testonly/tree_fuzz_test.go
@@ -14,9 +14,9 @@ import (
 
 // Compute and verify consistency proofs
 func FuzzConsistencyProofAndVerify(f *testing.F) {
-	for size := 0; size <= 8; size++ {
-		for end := 0; end <= size; end++ {
-			for begin := 0; begin <= end; begin++ {
+	for size := 1; size <= 8; size++ {
+		for end := 1; end <= size; end++ {
+			for begin := 1; begin <= end; begin++ {
 				f.Add(uint64(size), uint64(begin), uint64(end))
 			}
 		}

--- a/testonly/tree_fuzz_test.go
+++ b/testonly/tree_fuzz_test.go
@@ -30,6 +30,9 @@ func FuzzConsistencyProofAndVerify(f *testing.F) {
 		if begin > end || end > size {
 			return
 		}
+		if begin == 0 && end > 0 {
+			return
+		}
 		tree := newTree(genEntries(size))
 		p, err := tree.ConsistencyProof(begin, end)
 		t.Logf("proof=%v", p)


### PR DESCRIPTION
This is useful for other teams in the transparency space and was requested via the transparency-dev Slack channel. The new method is similar in essence to RootFromInclusionProof so fits in within the API.

As noted in the CHANGELOG, this change fixes a logical bug in the previous code that would have successfully verified an _empty_ proof from a tree size of 0 to any other tree size. In this change, trying to verify a consistency from a tree size of 0 to any other size than 0 will be considered an error, no matter what proof is provided.
