### PR TITLE
Bump go version to 1.22.7

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,5 @@
 # https://google.github.io/clusterfuzzlite/build-integration/#dockerfile
-FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:c7f01a616db0fc554d98edbd7d49a7177197f77fd4e1371bcb7774d7eac8216d
+FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:37d560af1d31ae8d339902acaedb8eb6fdf3f04469706f39e3bbea44fa3fdeec
 COPY . $SRC/merkle
 WORKDIR $SRC/merkle
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.22.x, 1.23.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,13 +10,12 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
-    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: go.mod
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.54.1
+          version: v1.55.1
+          args: --timeout=8m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: 1.17
+          go-version-file: go.mod
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,7 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -19,5 +19,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@dd0578b371c987f96d1185abb54344b44352bd58 # v1.0.3
         with:
-          go-version-input: 1.21.11
+          go-version-file: go.mod
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/transparency-dev/merkle
 
-go 1.22.7
+go 1.22
+
+toolchain go1.22.7
 
 require github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/transparency-dev/merkle
 
-go 1.20
+go 1.22
 
 require github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/transparency-dev/merkle
 
-go 1.22
+go 1.22.7
 
 require github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/transparency-dev/merkle
 
 go 1.22
 
-toolchain go1.22.7
-
 require github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Updated lint and vuln checks to pin to the version in go.mod file.
