### PR TITLE
Switch to math/rand/v2

### DIFF
--- a/compact/range_test.go
+++ b/compact/range_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"testing"
 
@@ -272,9 +272,9 @@ func TestMergeInBatches(t *testing.T) {
 
 // Build many trees of random size by randomly merging their sub-ranges.
 func TestMergeRandomly(t *testing.T) {
-	for seed := int64(1); seed < 100; seed++ {
+	for seed := uint64(1); seed < 100; seed++ {
 		t.Run(fmt.Sprintf("seed:%d", seed), func(t *testing.T) {
-			rnd := rand.New(rand.NewSource(seed))
+			rnd := rand.New(rand.NewPCG(0, seed))
 			numNodes := rand.Uint64() % 500
 			t.Logf("Tree size: %d", numNodes)
 
@@ -287,7 +287,7 @@ func TestMergeRandomly(t *testing.T) {
 						t.Fatalf("Append(%d): %v", begin, err)
 					}
 				} else if begin < end {
-					mid := begin + uint64(rnd.Int63n(int64(end-begin)))
+					mid := begin + rnd.Uint64N(end-begin)
 					if err := rng.AppendRange(mergeAll(begin, mid), visit); err != nil {
 						t.Fatalf("AppendRange(%d,%d): %v", begin, mid, err)
 					}

--- a/testonly/tree_test.go
+++ b/testonly/tree_test.go
@@ -17,7 +17,7 @@ package testonly
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 
@@ -140,11 +140,11 @@ func TestTreeConsistencyProof(t *testing.T) {
 func TestTreeConsistencyProofFuzz(t *testing.T) {
 	entries := genEntries(256)
 
-	for treeSize := int64(1); treeSize <= 256; treeSize++ {
+	for treeSize := uint64(1); treeSize <= 256; treeSize++ {
 		mt := newTree(entries[:treeSize])
 		for i := 0; i < 8; i++ {
-			size2 := uint64(rand.Int63n(treeSize + 1))
-			size1 := uint64(rand.Int63n(int64(size2) + 1))
+			size2 := rand.Uint64N(treeSize + 1)
+			size1 := rand.Uint64N(size2 + 1)
 
 			got, err := mt.ConsistencyProof(size1, size2)
 			if err != nil {


### PR DESCRIPTION
The new APIs allow for some cleanup in the common usages we have around uint64. The only downside is that this is go1.22+, but we've already committed to that in the go.mod file.
