### PR TITLE
Generate subtree inclusion proofs

### DIFF
--- a/proof/proof.go
+++ b/proof/proof.go
@@ -219,10 +219,27 @@ func reverse(ids []compact.NodeID) {
 	}
 }
 
+// isSubTreeValid returns whether a subtree covers a valid range.
+// A subtree is valid if there exist a parent tree node to:
+// - all the subtree nodes
+// - no extra node to the left of the subtree
+// - potentially extra nodes to the right of the subtree
 func isSubtreeValid(start, end uint64) bool {
-	shift := bits.Len64(end - start - 1)
-	if shift >= 64 {
-		return start == 0
+	l := end - start
+	if start == 0 {
+		return true
+	} else if (l) > uint64(1)<<63 {
+		// special-case large subtree to avoid panic
+		return false
 	}
-	return start%(uint64(1)<<shift) == 0
+	return start%bitCeil(l) == 0
+}
+
+// bitCeil returns the smallest power of 2 larger than n.
+// Panics if n > 2^63.
+func bitCeil(n uint64) uint64 {
+	if n <= 1 {
+		return 1
+	}
+	return uint64(1) << bits.Len64(n-1)
 }

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -52,6 +52,35 @@ func Inclusion(index, size uint64) (Nodes, error) {
 	return nodes(index, 0, size).skipFirst(), nil
 }
 
+// SubtreeInclusion returns the information on how to fetch and construct an inclusion
+// proof for the given leaf index in a log Merkle subtree covering [start, end).
+// It requires:
+//   - 0 <= start <= index < end
+//   - start to be a multiple of the smallest power of two greater than or equal to
+//     (end - start)
+func SubtreeInclusion(index, start, end uint64) (Nodes, error) {
+	if start >= end {
+		return Nodes{}, fmt.Errorf("start %d greater than or equal to end %d", start, end)
+	}
+	if index < start || index > end {
+		return Nodes{}, fmt.Errorf("index %d out of bounds for subtree range [%d, %d)", index, start, end)
+	}
+	if err := checkSubtreeAlignment(start, end); err != nil {
+		return Nodes{}, err
+	}
+
+	// Shift the subtree to the left such that it starts at 0.
+	p := nodes(index-start, 0, end-start)
+
+	// Shift all nodes back to the right.
+	for n := range p.IDs {
+		p.IDs[n].Index += start >> p.IDs[n].Level
+	}
+	p.ephem.Index += start >> p.ephem.Level
+
+	return p.skipFirst(), nil
+}
+
 // Consistency returns the information on how to fetch and construct a
 // consistency proof between the two given tree sizes of a log Merkle tree. It
 // requires 0 <= size1 <= size2.
@@ -188,4 +217,16 @@ func reverse(ids []compact.NodeID) {
 	for i, j := 0, len(ids)-1; i < j; i, j = i+1, j-1 {
 		ids[i], ids[j] = ids[j], ids[i]
 	}
+}
+
+func checkSubtreeAlignment(start, end uint64) error {
+	shift := bits.Len64(end - start - 1)
+	if shift >= 64 {
+		if start != 0 {
+			return fmt.Errorf("start %d not a multiple of bit_ceil(end - start)", start)
+		}
+	} else if bc := uint64(1) << shift; start%bc != 0 {
+		return fmt.Errorf("start %d not a multiple of bit_ceil(end - start) = %d", start, bc)
+	}
+	return nil
 }

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -65,8 +65,8 @@ func SubtreeInclusion(index, start, end uint64) (Nodes, error) {
 	if index < start || index >= end {
 		return Nodes{}, fmt.Errorf("index %d out of bounds for subtree [%d, %d)", index, start, end)
 	}
-	if err := checkSubtreeAlignment(start, end); err != nil {
-		return Nodes{}, err
+	if !isSubtreeValid(start, end) {
+		return Nodes{}, fmt.Errorf("start %d not a multiple of bit_ceil(end - start) = %d", start, end-start)
 	}
 
 	// Shift the subtree to the left, such that it starts at 0.
@@ -219,14 +219,10 @@ func reverse(ids []compact.NodeID) {
 	}
 }
 
-func checkSubtreeAlignment(start, end uint64) error {
+func isSubtreeValid(start, end uint64) bool {
 	shift := bits.Len64(end - start - 1)
 	if shift >= 64 {
-		if start != 0 {
-			return fmt.Errorf("start %d not a multiple of bit_ceil(end - start)", start)
-		}
-	} else if bc := uint64(1) << shift; start%bc != 0 {
-		return fmt.Errorf("start %d not a multiple of bit_ceil(end - start) = %d", start, bc)
+		return start == 0
 	}
-	return nil
+	return start%(uint64(1)<<shift) == 0
 }

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -76,6 +76,8 @@ func SubtreeInclusion(index, start, end uint64) (Nodes, error) {
 	for n := range p.IDs {
 		p.IDs[n].Index += start >> p.IDs[n].Level
 	}
+	// For consistency, always shift p.ephem, regardless of whether it will be
+	// used by the proof.
 	p.ephem.Index += start >> p.ephem.Level
 
 	return p, nil
@@ -163,6 +165,8 @@ func nodes(index uint64, level uint, size uint64) Nodes {
 		len1, len2 = 0, 0
 	}
 
+	// Edge case: For perfect trees the ephemeral node is the sibling of the root
+	// However, it will not be used in any proof.
 	return Nodes{IDs: nodes, begin: len1, end: len2, ephem: fork.Sibling()}
 }
 
@@ -236,7 +240,7 @@ func isSubtreeValid(start, end uint64) bool {
 }
 
 // bitCeil returns the smallest power of 2 larger than n.
-// Panics if n > 2^63.
+// MUST NOT be used with n larger than uint64(1)<<63.
 func bitCeil(n uint64) uint64 {
 	if n <= 1 {
 		return 1

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -62,23 +62,23 @@ func SubtreeInclusion(index, start, end uint64) (Nodes, error) {
 	if start >= end {
 		return Nodes{}, fmt.Errorf("start %d greater than or equal to end %d", start, end)
 	}
-	if index < start || index > end {
-		return Nodes{}, fmt.Errorf("index %d out of bounds for subtree range [%d, %d)", index, start, end)
+	if index < start || index >= end {
+		return Nodes{}, fmt.Errorf("index %d out of bounds for subtree [%d, %d)", index, start, end)
 	}
 	if err := checkSubtreeAlignment(start, end); err != nil {
 		return Nodes{}, err
 	}
 
-	// Shift the subtree to the left such that it starts at 0.
-	p := nodes(index-start, 0, end-start)
+	// Shift the subtree to the left, such that it starts at 0.
+	p := nodes(index-start, 0, end-start).skipFirst()
 
-	// Shift all nodes back to the right.
+	// Shift nodes back to the right, in line with the original subtree position.
 	for n := range p.IDs {
 		p.IDs[n].Index += start >> p.IDs[n].Level
 	}
 	p.ephem.Index += start >> p.ephem.Level
 
-	return p.skipFirst(), nil
+	return p, nil
 }
 
 // Consistency returns the information on how to fetch and construct a

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -16,7 +16,6 @@ package proof
 
 import (
 	"fmt"
-	"math/bits"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -426,7 +425,7 @@ func TestInclusionSubtreeSucceedsUpToTreeSize(t *testing.T) {
 	const maxSize = uint64(555)
 	for sbe := uint64(1); sbe <= maxSize; sbe++ {
 		for sbs := uint64(0); sbs < sbe; sbs++ {
-			if bc := uint64(1) << bits.Len64(sbe-sbs-1); sbs%bc != 0 {
+			if !isSubtreeValid(sbs, sbe) {
 				continue
 			}
 			for i := sbs; i < sbe; i++ {

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -16,6 +16,7 @@ package proof
 
 import (
 	"fmt"
+	"math/bits"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -113,6 +114,179 @@ func TestInclusion(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d:%d", tc.size, tc.index), func(t *testing.T) {
 			proof, err := Inclusion(tc.index, tc.size)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("accepted bad params")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("Inclusion: %v", err)
+			}
+			// Ignore the ephemeral node, it is tested separately.
+			proof.ephem = compact.NodeID{}
+			if diff := cmp.Diff(tc.want, proof, cmp.AllowUnexported(Nodes{})); diff != "" {
+				t.Errorf("paths mismatch:\n%v", diff)
+			}
+		})
+	}
+}
+
+// TestSubtreeInclusion contains subtree inclusion proof tests. For reference, consider the
+// following example of a tree from RFC 6962:
+//
+//	                        aaaaa                                   <== Level 4
+//	                         / \
+//	               ...                   ...
+//	               /                       \
+//	              /                         \
+//	             /                           \
+//	           aaaa                         bbbb                    <== Level 3
+//	          /    \                       /    \
+//	         /      \                     /      \
+//	        /        \                   /        \
+//	       /          \                 /          \
+//	      /            \               /            \
+//	    aaa            bbb           ccc            ddd             <== Level 2
+//	    / \            / \           / \            / \
+//	   /   \          /   \         /   \          /   \
+//	  /     \        /     \       /     \        /     \
+//	 aa      bb     cc     dd     ee      ff     gg    hh      ii   <== Level 1
+//	/ \     / \    / \    / \    / \     / \    / \    / \    / \
+//	a b     c d    e f    g h    i j     k l    m n    o p    q r   <== Level 0
+//	| |     | |    | |    | |    | |     | |    | |    | |    | |
+//	d0 d1   d2 d3  d4 d5  d6 d7  d8 d9   d10    d12    d14    d16
+//	                                       |      |      |      |
+//	                                       d11    d13    d15    d17
+//
+// Our storage node layers are always populated from the bottom up, hence the
+// gaps above ii.
+func TestSubtreeInclusion(t *testing.T) {
+	id := compact.NewNodeID
+	nodes := func(ids ...compact.NodeID) Nodes {
+		return Nodes{IDs: ids}
+	}
+	rehash := func(begin, end int, ids ...compact.NodeID) Nodes {
+		return Nodes{IDs: ids, begin: begin, end: end}
+	}
+	for _, tc := range []struct {
+		index   uint64 // Leaf index in the requested tree.
+		start   uint64 // The smallest index of the subtree.
+		end     uint64 // The largest index of the subtree + 1.
+		want    Nodes
+		wantErr bool
+	}{
+		// Errors.
+		{start: 0, end: 0, index: 0, wantErr: true},         // everything at 0
+		{start: 1, end: 1, index: 0, wantErr: true},         // start = end
+		{start: 2, end: 1, index: 0, wantErr: true},         // start > end
+		{start: 1, end: 2, index: 0, wantErr: true},         // index out of bounds left
+		{start: 0, end: 2, index: 3, wantErr: true},         // index out of bounds right
+		{start: 0, end: 3, index: 3, wantErr: true},         // index out of bounds right
+		{start: 3, end: 5, index: 3, wantErr: true},         // start not multiple of bit_ceil(len)
+		{start: 1, end: 1<<63 + 2, index: 1, wantErr: true}, // start not multiple of bit_ceil(len) with big tree
+
+		// Small trees.
+		{start: 0, end: 1, index: 0, want: Nodes{IDs: []compact.NodeID{}}},
+		{start: 0, end: 2, index: 0, want: nodes(id(0, 1))},                  // b
+		{start: 0, end: 2, index: 1, want: nodes(id(0, 0))},                  // a
+		{start: 0, end: 3, index: 1, want: rehash(1, 2, id(0, 0), id(0, 2))}, // a c
+
+		// Small subtrees.
+		// Small tree shifted by bit_ceil(len).
+		{start: 1, end: 2, index: 1, want: Nodes{IDs: []compact.NodeID{}}},
+		{start: 2, end: 3, index: 2, want: Nodes{IDs: []compact.NodeID{}}},
+		{start: 7, end: 8, index: 7, want: Nodes{IDs: []compact.NodeID{}}},
+		{start: 2, end: 4, index: 2, want: nodes(id(0, 3))}, // d
+		{start: 2, end: 4, index: 3, want: nodes(id(0, 2))}, // c
+		{start: 4, end: 7, index: 4, want: rehash(1, 2,
+			id(0, 5), id(0, 6))}, // f, j
+		{start: 4, end: 7, index: 6, want: nodes(id(1, 2))}, // i
+
+		// Tree of size 7.
+		{start: 0, end: 7, index: 0, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 1), id(1, 1), id(0, 6), id(1, 2))}, // b bb g cc
+		{start: 0, end: 7, index: 1, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 0), id(1, 1), id(0, 6), id(1, 2))}, // a bb g cc
+		{start: 0, end: 7, index: 2, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 3), id(1, 0), id(0, 6), id(1, 2))}, // d aa g cc
+		{start: 0, end: 7, index: 3, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 2), id(1, 0), id(0, 6), id(1, 2))}, // c aa g cc
+		{start: 0, end: 7, index: 4, want: rehash(1, 2,
+			id(0, 5), id(0, 6), id(2, 0))}, // f g aaa
+		{start: 0, end: 7, index: 5, want: rehash(1, 2,
+			id(0, 4), id(0, 6), id(2, 0))}, // e g aaa
+		{start: 0, end: 7, index: 6, want: nodes(id(1, 2), id(2, 0))}, // i k
+
+		// Subtree of size 7.
+		// Tree of size 7 shifted by bit_ceil(len).
+		{start: 8, end: 15, index: 8, want: rehash(2, 4, // ddd=hash(gg,o)
+			id(0, 9), id(1, 5), id(0, 14), id(1, 6))}, // j ff o gg
+		{start: 8, end: 15, index: 9, want: rehash(2, 4, // ddd=hash(gg,o)
+			id(0, 8), id(1, 5), id(0, 14), id(1, 6))}, // j ff o gg
+		{start: 8, end: 15, index: 10, want: rehash(2, 4, // ddd=hash(gg,o)
+			id(0, 11), id(1, 4), id(0, 14), id(1, 6))}, // l ee o gg
+		{start: 8, end: 15, index: 11, want: rehash(2, 4, // ddd=hash(gg, o)
+			id(0, 10), id(1, 4), id(0, 14), id(1, 6))}, // k ee o gg
+		{start: 8, end: 15, index: 12, want: rehash(1, 2,
+			id(0, 13), id(0, 14), id(2, 2))}, // n o ccc
+		{start: 8, end: 15, index: 13, want: rehash(1, 2,
+			id(0, 12), id(0, 14), id(2, 2))}, // m o ccc
+		{start: 8, end: 15, index: 14, want: nodes(id(1, 6), id(2, 2))}, // gg ccc
+
+		// Smaller trees within a bigger stored tree.
+		// start = 0
+		{start: 0, end: 4, index: 2, want: nodes(id(0, 3), id(1, 0))},                  // d aa
+		{start: 0, end: 5, index: 3, want: rehash(2, 3, id(0, 2), id(1, 0), id(0, 4))}, // c aa e
+		{start: 0, end: 6, index: 3, want: rehash(2, 3, id(0, 2), id(1, 0), id(1, 2))}, // c aa i
+		{start: 0, end: 6, index: 4, want: nodes(id(0, 5), id(2, 0))},                  // f aaa
+		{start: 0, end: 7, index: 1, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 0), id(1, 1), id(0, 6), id(1, 2))}, // a bb g cc
+		{start: 0, end: 7, index: 3, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 2), id(1, 0), id(0, 6), id(1, 2))}, // c aa g cc
+		// Shifted by bit_ceil(len).
+		{start: 4, end: 8, index: 6, want: nodes(id(0, 7), id(1, 2))},                      // h cc
+		{start: 8, end: 13, index: 11, want: rehash(2, 3, id(0, 10), id(1, 4), id(0, 12))}, // k ee m
+		{start: 8, end: 14, index: 11, want: rehash(2, 3, id(0, 10), id(1, 4), id(1, 6))},  // k, ee, gg
+		{start: 8, end: 14, index: 12, want: nodes(id(0, 13), id(2, 2))},                   // n ccc
+		{start: 8, end: 15, index: 9, want: rehash(2, 4, // ddd=hash(gg,o)
+			id(0, 8), id(1, 5), id(0, 14), id(1, 6))}, // i ff o gg
+		{start: 8, end: 15, index: 11, want: rehash(2, 4, // bbb=hash(cc,g)
+			id(0, 10), id(1, 4), id(0, 14), id(1, 6))}, // k ff q gg
+
+		// Some rehashes in the middle of the returned list.
+		{start: 0, end: 15, index: 10, want: rehash(2, 4,
+			id(0, 11), id(1, 4),
+			id(0, 14), id(1, 6),
+			id(3, 0),
+		)},
+		{start: 16, end: 31, index: 26, want: rehash(2, 4,
+			id(0, 27), id(1, 12),
+			id(0, 30), id(1, 14),
+			id(3, 2),
+		)},
+		{start: 0, end: 31, index: 24, want: rehash(2, 4,
+			id(0, 25), id(1, 13),
+			id(0, 30), id(1, 14),
+			id(3, 2), id(4, 0),
+		)},
+		{start: 32, end: 63, index: 56, want: rehash(2, 4,
+			id(0, 57), id(1, 29),
+			id(0, 62), id(1, 30),
+			id(3, 6), id(4, 2),
+		)},
+		{start: 0, end: 95, index: 81, want: rehash(3, 6,
+			id(0, 80), id(1, 41), id(2, 21),
+			id(0, 94), id(1, 46), id(2, 22),
+			id(4, 4), id(6, 0),
+		)},
+		{start: 128, end: 223, index: 209, want: rehash(3, 6,
+			id(0, 208), id(1, 105), id(2, 53),
+			id(0, 222), id(1, 110), id(2, 54),
+			id(4, 12), id(6, 2),
+		)},
+	} {
+		t.Run(fmt.Sprintf("%d:%d:%d", tc.start, tc.end, tc.index), func(t *testing.T) {
+			proof, err := SubtreeInclusion(tc.index, tc.start, tc.end)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("accepted bad params")
@@ -248,6 +422,22 @@ func TestInclusionSucceedsUpToTreeSize(t *testing.T) {
 	}
 }
 
+func TestInclusionSubtreeSucceedsUpToTreeSize(t *testing.T) {
+	const maxSize = uint64(555)
+	for sbe := uint64(1); sbe <= maxSize; sbe++ {
+		for sbs := uint64(0); sbs < sbe; sbs++ {
+			if bc := uint64(1) << bits.Len64(sbe-sbs-1); sbs%bc != 0 {
+				continue
+			}
+			for i := sbs; i < sbe; i++ {
+				if _, err := SubtreeInclusion(i, sbs, sbe); err != nil {
+					t.Errorf("SubtreeInclusion(i:%d, sbs:%d, sbe: %d) = %v", i, sbs, sbe, err)
+				}
+			}
+		}
+	}
+}
+
 func TestConsistencySucceedsUpToTreeSize(t *testing.T) {
 	const maxSize = uint64(100)
 	for s1 := uint64(1); s1 < maxSize; s1++ {
@@ -296,6 +486,73 @@ func TestEphem(t *testing.T) {
 			nodes, err := Inclusion(tc.index, tc.size)
 			if err != nil {
 				t.Fatalf("Inclusion: %v", err)
+			}
+			got, _, _ := nodes.Ephem()
+			if want := tc.want; got != want {
+				t.Errorf("Ephem: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestEphemSubtree(t *testing.T) {
+	id := compact.NewNodeID
+	for _, tc := range []struct {
+		index uint64
+		start uint64
+		end   uint64
+		want  compact.NodeID
+	}{
+		// Edge case: For perfect trees (resp. subtree) the ephemeral node is the
+		// sibling of the root (resp subtree root). However, it will not be used in
+		// the proof, as the corresponding subtree is empty.
+		{index: 3, start: 0, end: 32, want: id(5, 1)},
+		{index: 35, start: 32, end: 64, want: id(5, 2)},
+
+		// start = 0
+		{index: 0, start: 0, end: 9, want: id(3, 1)},
+		{index: 0, start: 0, end: 13, want: id(3, 1)},
+		{index: 7, start: 0, end: 13, want: id(3, 1)},
+		{index: 8, start: 0, end: 13, want: id(2, 3)},
+		{index: 11, start: 0, end: 13, want: id(2, 3)},
+		// More edge cases when the computed ephemeral node is not used in the
+		// proof, because it is fully outside the tree border.
+		{index: 12, start: 0, end: 13, want: id(0, 13)},
+		{index: 13, start: 0, end: 14, want: id(1, 7)},
+		// Shifted by bit_ceil(len).
+		{index: 16, start: 16, end: 25, want: id(3, 3)},
+		{index: 16, start: 16, end: 29, want: id(3, 3)},
+		{index: 23, start: 16, end: 29, want: id(3, 3)},
+		{index: 24, start: 16, end: 29, want: id(2, 7)},
+		{index: 27, start: 16, end: 29, want: id(2, 7)},
+		// More edge cases when the computed ephemeral node is not used in the
+		// proof, because it is fully outside the tree border.
+		{index: 28, start: 16, end: 29, want: id(0, 29)},
+		{index: 29, start: 16, end: 30, want: id(1, 15)},
+
+		// There is only one node (level 0, index 1024) in the right subtree, but
+		// the ephemeral node is at level 10 rather than level 0. This is because
+		// for the purposes of the proof this node is *effectively* at level 10.
+		{index: 123, start: 0, end: 1025, want: id(10, 1)},
+		// Shifted by bit_ceil(len).
+		{index: 2171, start: 2048, end: 3073, want: id(10, 3)},
+
+		{index: 0, start: 0, end: 0xFFFF, want: id(15, 1)},
+		{index: 0xF000, start: 0, end: 0xFFFF, want: id(11, 0x1F)},
+		{index: 0xFF00, start: 0, end: 0xFFFF, want: id(7, 0x1FF)},
+		{index: 0xFFF0, start: 0, end: 0xFFFF, want: id(3, 0x1FFF)},
+		{index: 0xFFFF - 1, start: 0, end: 0xFFFF, want: id(0, 0xFFFF)},
+		// Shifted by bit_ceil(len).
+		{index: 0x10000, start: 0x10000, end: 0x1FFFF, want: id(15, 3)},
+		{index: 0x1F000, start: 0x10000, end: 0x1FFFF, want: id(11, 0x3F)},
+		{index: 0x1FF00, start: 0x10000, end: 0x1FFFF, want: id(7, 0x3FF)},
+		{index: 0x1FFF0, start: 0x10000, end: 0x1FFFF, want: id(3, 0x3FFF)},
+		{index: 0x1FFFF - 1, start: 0x10000, end: 0x1FFFF, want: id(0, 0x1FFFF)},
+	} {
+		t.Run(fmt.Sprintf("%d:%d:%d", tc.index, tc.start, tc.end), func(t *testing.T) {
+			nodes, err := SubtreeInclusion(tc.index, tc.start, tc.end)
+			if err != nil {
+				t.Fatalf("SubtreeInclusion: %v", err)
 			}
 			got, _, _ := nodes.Ephem()
 			if want := tc.want; got != want {


### PR DESCRIPTION
Towards #225.

This PR introduces `SubtreeInclusion` and allows generating inclusion proofs for a leaf in a given subtree. Verification will come in a later PR.

This implementation:
 - checks that the inputs are valid
 - shifts the subtree to make it start at 0
 - fetches the corresponding inclusion proof nodes
 - shifts all nodes back to their original position

The tests for this function are based on the existing tests of Inclusion, with the addition of:
 - Pathological cases
 - Existing test cases, all shifted by `bit_ceil(end-start)`. I believe this is enough. Specifically, I don't think that we need to add tests shifted by `x*bit_ceil(end-start)`. We can always add more tests later if need be. We should probably add subtree tests inside `testonly/` as well.

Alternatives explored:
 - non-shifting: by modifying the `nodes` function to accept `start` and `end` index. It added complexity to that function without clear benefits. I doubt that the performance would be noticeable.
 - with the current approach, make `Inclusion` call `SubtreeInclusion`: this works, but adds unnecessary checks to `Inclusion`. I like how simple `Inclusion` is today.
 - with the current approach, in `SubtreeInclusion`, run some input validation checks, then call `Inclusion` which would call further input validation tests, then shift nodes back. This would just make error message more confusing, with little benefits.

Let me know what you think, and we'll take it from there.
