### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -2,6 +2,7 @@ on: [push, pull_request]
 name: Test Go
 permissions:
   contents: read
+  id-token: write
 jobs:
   test:
     strategy:
@@ -16,3 +17,5 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
     - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        use_oidc: true


### PR DESCRIPTION
Towards #230.

Inspired by https://github.com/transparency-dev/witness/pull/521.

Codecov is broken for ~all our t-dev/ repos other than t-dev/witness. I could identify four setups:
 - codecov used to work, and [was configured](https://app.codecov.io/github/AlCutter) by @AlCutter, but isn't working anymore, like in this repo. This PR should fix it for this repo, like https://github.com/transparency-dev/witness/pull/521 fixed it for t-dev/witness. If it works, we can send the same change to other repos.
 - repos for which codecov never worked, but I guess that we simply copied over the workflow definitions: https://github.com/transparency-dev/incubator
 - repos that don't have codecov configured, nor any other code coverage analysis like t-dev/tessera or t-dev/tesseract.
 
Let's fix t-dev/merkle since it complains in every single PR.
Long term, we should:
 - Identify whether we really care test coverage analysis.
 - If yes, then find a sustainable solution for all our repos and enable it. Ideas: either configure codecov such that it doesn't break silently for years, use a custom action with the go toolchain, or any other solution that I'm not aware of.