### PR TITLE
[old] Subtree consistency proof verification

### DIFF
--- a/proof/verify.go
+++ b/proof/verify.go
@@ -139,15 +139,18 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
 	// inclusion proof for entry |size1-1| in a tree of size |size2|.
 
-	// Verify the first root.
-	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-	hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
-	hash1 = chainBorderRight(hasher, hash1, proof[inner:])
-	if err := verifyMatch(hash1, root1); err != nil {
-		return nil, err
+	// Verify the first root, if included in the proof.
+	if start != 0 {
+		mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
+		hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
+		hash1 = chainBorderRight(hasher, hash1, proof[inner:])
+		if err := verifyMatch(hash1, root1); err != nil {
+			return nil, err
+		}
 	}
 
 	// Verify the second root.
+	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
 	hash2 := chainInner(hasher, seed, proof[:inner], mask)
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -222,13 +222,12 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// belong to the subtree. We must verify that these nodes chain correctly to
 	// the argument subtree root.
 	if pStart == 1 {
+		// Helper to only chain nodes to the right of |start|, from level |shift|.
 		rightMask := (end - 1) >> uint(shift)
 		leftMask := start >> uint(shift)
-		// Clamp the proof such that it only includes nodes inside the subtree.
-		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
 		// First, partially reconstruct the subtree root (hash1) by chaining left siblings
-		// from the inner part of the proof, and inside the subtree.
-		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
+		// from the inner part of the proof, skipping right siblings which lie outside the subtree.
+		hash1 := chainInnerRight(hasher, seed, proof[:inner], leftMask, rightMask)
 
 		// Then, hash the remaining border nodes that belong to the subtree.
 		if border > 0 {
@@ -242,6 +241,7 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	}
 
 	// Verify the second root.
+	// First, chain the bottom part of the proof.
 	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
 	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
 	// Then, chain the upper part of the proof.
@@ -282,11 +282,16 @@ func chainInner(hasher merkle.LogHasher, seed []byte, proof [][]byte, index uint
 }
 
 // chainInnerRight computes a subtree hash like chainInner, but only takes
-// hashes to the left from the path into consideration, which effectively means
-// the result is a hash of the corresponding earlier version of this subtree.
-func chainInnerRight(hasher merkle.LogHasher, seed []byte, proof [][]byte, index uint64) []byte {
+// hashes within [leftMask, rightMask]. That effectively means taking only
+// hashes to the left of the path the proof follows, which results in hashing
+// the corresponding earlier version of this subtree.
+func chainInnerRight(hasher merkle.LogHasher, seed []byte, proof [][]byte, leftMask, rightMask uint64) []byte {
 	for i, h := range proof {
-		if (index>>uint(i))&1 == 1 {
+		// Return as soon as we're outside of leftMask.
+		if rightMask>>uint(i) == leftMask>>uint(i) {
+			return seed
+		}
+		if (rightMask>>uint(i))&1 == 1 {
 			seed = hasher.HashChildren(h, seed)
 		}
 	}

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -140,8 +140,8 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 }
 
 // RootFromSubtreeConsistencyProof calculates the expected root hash for a
-// parent tree of the given size, from a subtree [start, end) with its root and
-// a consistency proof.
+// parent tree of the given size, from a subtree [start, end) root and a
+// consistency proof.
 //
 // It requires:
 //   - 0 <= start < end <= size.
@@ -198,7 +198,13 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
 
+	// The first node of the proof is the root of the rightmost subtree within
+	// the argument subtree.
 	seed, pStart := proof[0], 1
+	// Unless the argument subtree is full, in which case that rightmost subtree
+	// is the argument subtree itself. Its root is not included in the proof
+	// since a client verifying a subtree inclusion proof is expected to already
+	// know what the root of that subtree is.
 	if (end - start) == 1<<uint(shift) {
 		seed, pStart = subRoot, 0
 	}
@@ -208,15 +214,23 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	}
 	proof = proof[pStart:]
 
+	// Compute the root of the [start, end) subtree for trees of sizes
+	// |end| and |size|.
 	subtreeRoot, grownSubtreeRoot, remainingProof := chainSubtree(hasher, seed, proof, start, end, size)
 	if err := verifyMatch(subtreeRoot, subRoot); err != nil {
 		return nil, err
 	}
 
-	h := bits.Len64((end - 1) ^ start)
-	macroIndex := start >> uint(h)
-	macroSize := ((size - 1) >> uint(h)) + 1
-	return RootFromInclusionProof(hasher, macroIndex, macroSize, grownSubtreeRoot, remainingProof)
+	// The remainder of the proof is an inclusion proof for grownSubtreeRoot
+	// into the parent tree of size |size|.
+	// Shift the tree down for that node to be a leaf.
+	// xor trims the common prefix between the first and last entry. The bit len
+	// of the result is the height of the subtree.
+	srHeight := bits.Len64((end - 1) ^ start)
+	// shifting indexes srHeight times gives the tree size at level srHeight.
+	sIndex := start >> uint(srHeight)
+	sSize := ((size - 1) >> uint(srHeight)) + 1
+	return RootFromInclusionProof(hasher, sIndex, sSize, grownSubtreeRoot, remainingProof)
 }
 
 // chainSubtree hashes nodes from proof up to subtree [start, end)'s root

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -139,13 +139,16 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	return rootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
 }
 
-// RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
-// of the given size, provided with a subtree [start, end), its root and a
-// consistency proof.
+// RootFromSubtreeConsistencyProof calculates the expected root hash for a
+// parent tree of the given size, from a subtree [start, end) with its root and
+// a consistency proof.
+//
 // It requires:
 //   - 0 <= start < end <= size.
 //   - start to be a multiple of the smallest power of two greater than or equal to
 //     (end - start)
+//
+// Returns an error if the proof does not hash to the provided subtree root.
 func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
 	err := isSubtreeValid(start, end)
 	switch {
@@ -161,28 +164,21 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
-	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, subRoot)
 }
 
-func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1 []byte) ([]byte, error) {
-	err := isSubtreeValid(start, end)
-	switch {
-	case err != nil:
-		return nil, fmt.Errorf("subtree invalid: %v", err)
-	case size < end:
-		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
-	case start == 0 && size == end:
-		if len(proof) > 0 {
-			return nil, errors.New("start=0 and end=size, but proof is not empty")
-		}
-		return root1, nil
-	case len(proof) == 0:
-		return nil, errors.New("empty proof")
-	// If the right end of the subtree overlaps with the right end of the tree,
-	// compute the tree root directly.
-	case end == size:
+func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
+	// If the right end of the subtree overlaps with the right end of the parent
+	// tree, the proof allows reconstructing the tree root directly from the
+	// argument subtree root |subRoot|.
+	if end == size {
+		// Find the root of the subtree.
+		// xor trims the common prefix between the first and last entry. The bit len
+		// of the result is the height of the subtree.
 		level := bits.Len64((end - 1) ^ start) // Height of the subtree.
 		index := start >> level
+		// To reconstruct the root from the subtree root, we need one left sibling
+		// node for each level where the subtree's ancestor is a right child.
 		want := bits.OnesCount64(index)
 		if got := len(proof); got != want {
 			return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
@@ -190,13 +186,28 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 		return chainBorderRight(hasher, subRoot, proof), nil
 	}
 
-	inner, border := decompInclProof(end-1, size)
+	// Otherwise, we need to:
+	//   - Verify that nodes in the proof that belongs to the subtree are consistent
+	//     with the argument subtree root |subRoot|.
+	//   - Reconstruct the parent tree root from the the argument subtree root
+	//     grown into a subtree of the parent tree of size |size|.
+	//
+	// Split the proof in two, where paths to leaves |end-1| and |size-1| diverge.
+	forkLevel, border := decompInclProof(end-1, size)
+	// Height of the rightmost full subtree within the argument subtree.
+	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
-	inner -= shift // Note: shift < inner if end < size.
+	// Number of level between the root of that subtree and the end the the first
+	// part of the proof.
+	inner := forkLevel - shift // Note: shift < inner if end < size.
 
-	// The proof includes the root hash for the sub-tree of size 2^shift.
+	// The first node of the proof is the root of the rightmost subtree within
+	// the argument subtree.
 	seed, pStart := proof[0], 1
-	// Unless the subtree is that very 2^shift.
+	// Unless the argument subtree is full, in which case that rightmost subtree
+	// is the argument subtree itself. Its root is not included in the proof
+	// since a client verifying a subtree inclusion proof is expected to already
+	// know what the root of that subtree is.
 	if (end - start) == 1<<uint(shift) {
 		seed, pStart = subRoot, 0
 	}
@@ -207,14 +218,22 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
 	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
-	// Verify the first root, if included in the proof.
-	if start != 0 {
+	// If the argument subtree is not full, the proof includes somes nodes that
+	// belong to the subtree. We must verify that these nodes chain correctly to
+	// the argument subtree root.
+	if pStart == 1 {
 		rightMask := (end - 1) >> uint(shift)
 		leftMask := start >> uint(shift)
+		// Clamp the proof such that it only includes nodes inside the subtree.
 		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
+		// First, partially reconstruct the subtree root (hash1) by chaining left siblings
+		// from the inner part of the proof, and inside the subtree.
 		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
+
+		// Then, hash the remaining border nodes that belong to the subtree.
 		if border > 0 {
-			k := border - bits.OnesCount64(start>>uint(inner))
+			// Only take border nodes that are to the right of |start| (inside the subtree).
+			k := border - bits.OnesCount64(start>>uint(forkLevel))
 			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
 		}
 		if err := verifyMatch(hash1, subRoot); err != nil {
@@ -225,6 +244,7 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// Verify the second root.
 	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
 	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
+	// Then, chain the upper part of the proof.
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil
 }
@@ -241,6 +261,8 @@ func decompInclProof(index, size uint64) (int, int) {
 }
 
 func innerProofSize(index, size uint64) int {
+	// Height of the first node where the paths of leaves at |index| and |size-1|
+	// diverge.
 	return bits.Len64(index ^ (size - 1))
 }
 

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -104,6 +104,20 @@ func VerifyConsistency(hasher merkle.LogHasher, size1, size2 uint64, proof [][]b
 	return verifyMatch(hash2, root2)
 }
 
+// VerifySubtreeConsistency checks that the passed-in subtree consistency proof
+// is valid between the passed in subtree indices and parent tree size, with
+// respect to the corresponding subtree root node hash. It Requires:
+//   - 0 <= start < end <= size.
+//   - start to be a multiple of the smallest power of two greater than or equal to
+//     (end - start)
+func VerifySubtreeConsistency(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1, root2 []byte) error {
+	hash2, err := RootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+	if err != nil {
+		return err
+	}
+	return verifyMatch(hash2, root2)
+}
+
 // RootFromConsistencyProof calculates the expected root hash for a tree of the
 // given size2, provided a tree of size1 with root1, and a consistency proof.
 // Requires 0 < size1 <= size2.
@@ -122,36 +136,80 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
+	return RootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
+}
 
-	inner, border := decompInclProof(size1-1, size2)
-	shift := bits.TrailingZeros64(size1)
-	inner -= shift // Note: shift < inner if size1 < size2.
+// RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
+// of the given size, provided with a subtree [start, end), its root and a
+// consistency proof.
+// It requires:
+//   - 0 <= start < end <= size.
+//   - start to be a multiple of the smallest power of two greater than or equal to
+//     (end - start)
+func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
+	err := isSubtreeValid(start, end)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("subtree invalid: %v", err)
+	case size < end:
+		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
+	case start == 0 && size == end:
+		if len(proof) > 0 {
+			return nil, errors.New("start=0 and end=size, but proof is not empty")
+		}
+		return subRoot, nil
+	case len(proof) == 0:
+		return nil, errors.New("empty proof")
+	// If the right end of the subtree overlaps with the right end of the tree,
+	// compute the tree root directly.
+	case end == size:
+		level := bits.Len64((end - 1) ^ start) // Height of the subtree.
+		index := start >> level
+		want := bits.OnesCount64(index)
+		if got := len(proof); got != want {
+			return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
+		}
+		return chainBorderRight(hasher, subRoot, proof), nil
+	}
+
+	inner, border := decompInclProof(end-1, size)
+	shift := bits.TrailingZeros64(end - start)
+	inner -= shift // Note: shift < inner if end < size.
 
 	// The proof includes the root hash for the sub-tree of size 2^shift.
-	seed, start := proof[0], 1
-	if size1 == 1<<uint(shift) { // Unless size1 is that very 2^shift.
-		seed, start = root1, 0
+	seed, pStart := proof[0], 1
+	// Unless the subtree is that very 2^shift.
+	if (end - start) == 1<<uint(shift) {
+		seed, pStart = subRoot, 0
 	}
-	if got, want := len(proof), start+inner+border; got != want {
+	if got, want := len(proof), pStart+inner+border; got != want {
 		return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
 	}
-	proof = proof[start:]
+	proof = proof[pStart:]
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
-	// inclusion proof for entry |size1-1| in a tree of size |size2|.
+	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
 	// Verify the first root, if included in the proof.
 	if start != 0 {
-		mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-		hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
-		hash1 = chainBorderRight(hasher, hash1, proof[inner:])
-		if err := verifyMatch(hash1, root1); err != nil {
+		rightMask := (end - 1) >> uint(shift)
+		leftMask := start >> uint(shift)
+		clampedLen := bits.Len64(rightMask ^ leftMask)
+		if clampedLen > inner {
+			clampedLen = inner
+		}
+		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
+		if border > 0 {
+			k := border - bits.OnesCount64(start>>uint(inner))
+			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
+		}
+		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
 		}
 	}
 
 	// Verify the second root.
-	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-	hash2 := chainInner(hasher, seed, proof[:inner], mask)
+	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
+	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil
 }

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -136,7 +136,7 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
-	return RootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
+	return rootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
 }
 
 // RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
@@ -158,6 +158,24 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 			return nil, errors.New("start=0 and end=size, but proof is not empty")
 		}
 		return subRoot, nil
+	case len(proof) == 0:
+		return nil, errors.New("empty proof")
+	}
+	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+}
+
+func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1 []byte) ([]byte, error) {
+	err := isSubtreeValid(start, end)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("subtree invalid: %v", err)
+	case size < end:
+		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
+	case start == 0 && size == end:
+		if len(proof) > 0 {
+			return nil, errors.New("start=0 and end=size, but proof is not empty")
+		}
+		return root1, nil
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	// If the right end of the subtree overlaps with the right end of the tree,
@@ -193,10 +211,7 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	if start != 0 {
 		rightMask := (end - 1) >> uint(shift)
 		leftMask := start >> uint(shift)
-		clampedLen := bits.Len64(rightMask ^ leftMask)
-		if clampedLen > inner {
-			clampedLen = inner
-		}
+		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
 		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
 		if border > 0 {
 			k := border - bits.OnesCount64(start>>uint(inner))

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -222,18 +222,15 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// belong to the subtree. We must verify that these nodes chain correctly to
 	// the argument subtree root.
 	if pStart == 1 {
-		// Helper to only chain nodes to the right of |start|, from level |shift|.
-		rightMask := (end - 1) >> uint(shift)
-		leftMask := start >> uint(shift)
-		// First, partially reconstruct the subtree root (hash1) by chaining left siblings
-		// from the inner part of the proof, skipping right siblings which lie outside the subtree.
-		hash1 := chainInnerRight(hasher, seed, proof[:inner], leftMask, rightMask)
-
-		// Then, hash the remaining border nodes that belong to the subtree.
-		if border > 0 {
-			// Only take border nodes that are to the right of |start| (inside the subtree).
-			k := border - bits.OnesCount64(start>>uint(forkLevel))
-			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
+		h := bits.Len64((end - 1) ^ start)
+		hash1 := seed
+		for i, lvl := 0, shift; lvl < h; lvl++ {
+			if ((end-1)>>lvl)&1 == 1 {
+				hash1 = hasher.HashChildren(proof[i], hash1)
+				i++
+			} else if lvl < forkLevel {
+				i++
+			}
 		}
 		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
@@ -275,23 +272,6 @@ func chainInner(hasher merkle.LogHasher, seed []byte, proof [][]byte, index uint
 		if (index>>uint(i))&1 == 0 {
 			seed = hasher.HashChildren(seed, h)
 		} else {
-			seed = hasher.HashChildren(h, seed)
-		}
-	}
-	return seed
-}
-
-// chainInnerRight computes a subtree hash like chainInner, but only takes
-// hashes within [leftMask, rightMask]. That effectively means taking only
-// hashes to the left of the path the proof follows, which results in hashing
-// the corresponding earlier version of this subtree.
-func chainInnerRight(hasher merkle.LogHasher, seed []byte, proof [][]byte, leftMask, rightMask uint64) []byte {
-	for i, h := range proof {
-		// Return as soon as we're outside of leftMask.
-		if rightMask>>uint(i) == leftMask>>uint(i) {
-			return seed
-		}
-		if (rightMask>>uint(i))&1 == 1 {
 			seed = hasher.HashChildren(h, seed)
 		}
 	}

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -193,57 +193,62 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	//     grown into a subtree of the parent tree of size |size|.
 	//
 	// Split the proof in two, where paths to leaves |end-1| and |size-1| diverge.
-	forkLevel, border := decompInclProof(end-1, size)
+	forkLevel := bits.Len64((end - 1) ^ (size - 1))
 	// Height of the rightmost full subtree within the argument subtree.
 	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
-	// Number of level between the root of that subtree and the end the the first
-	// part of the proof.
-	inner := forkLevel - shift // Note: shift < inner if end < size.
 
-	// The first node of the proof is the root of the rightmost subtree within
-	// the argument subtree.
 	seed, pStart := proof[0], 1
-	// Unless the argument subtree is full, in which case that rightmost subtree
-	// is the argument subtree itself. Its root is not included in the proof
-	// since a client verifying a subtree inclusion proof is expected to already
-	// know what the root of that subtree is.
 	if (end - start) == 1<<uint(shift) {
 		seed, pStart = subRoot, 0
 	}
-	if got, want := len(proof), pStart+inner+border; got != want {
-		return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
+	wantProofLen := pStart + (forkLevel - shift) + bits.OnesCount64((end-1)>>forkLevel)
+	if got := len(proof); got != wantProofLen {
+		return nil, fmt.Errorf("wrong proof size %d, want %d", got, wantProofLen)
 	}
 	proof = proof[pStart:]
-	// Now len(proof) == inner+border, and proof is effectively a suffix of
-	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
-	// If the argument subtree is not full, the proof includes somes nodes that
-	// belong to the subtree. We must verify that these nodes chain correctly to
-	// the argument subtree root.
-	if pStart == 1 {
-		h := bits.Len64((end - 1) ^ start)
-		hash1 := seed
-		for i, lvl := 0, shift; lvl < h; lvl++ {
-			if ((end-1)>>lvl)&1 == 1 {
-				hash1 = hasher.HashChildren(proof[i], hash1)
-				i++
-			} else if lvl < forkLevel {
-				i++
-			}
-		}
-		if err := verifyMatch(hash1, subRoot); err != nil {
-			return nil, err
-		}
+	subtreeRoot, grownSubtreeRoot, remainingProof := chainSubtree(hasher, seed, proof, start, end, size)
+	if err := verifyMatch(subtreeRoot, subRoot); err != nil {
+		return nil, err
 	}
 
-	// Verify the second root.
-	// First, chain the bottom part of the proof.
-	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
-	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
-	// Then, chain the upper part of the proof.
-	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
-	return hash2, nil
+	h := bits.Len64((end - 1) ^ start)
+	macroIndex := start >> uint(h)
+	macroSize := ((size - 1) >> uint(h)) + 1
+	return RootFromInclusionProof(hasher, macroIndex, macroSize, grownSubtreeRoot, remainingProof)
+}
+
+// chainSubtree hashes nodes from proof up to subtree [start, end)'s root
+// for trees of sizes |end| and |size|. Returns the two root hashes, and the
+// remaining proof hashes.
+func chainSubtree(hasher merkle.LogHasher, seed []byte, proof [][]byte, start, end, size uint64) ([]byte, []byte, [][]byte) {
+	// Height of the rightmost full subtree within the argument subtree.
+	// The proof starts at this level.
+	shift := bits.TrailingZeros64(end - start)
+	// xor trims the common prefix between the first and last entry. The bit len
+	// of the result is the height of the subtree.
+	h := bits.Len64((end - 1) ^ start)
+	// The level at which the path between nodes at indexs |end-1| and |size-1|
+	// separate.
+	forkLevel := bits.Len64((end - 1) ^ (size - 1))
+
+	subtreeRoot, grownSubtreeRoot := seed, seed
+	i := 0
+	for lvl := shift; lvl < h; lvl++ {
+		// If we're at a level where a left sibling is missing, hash it.
+		if ((end-1)>>lvl)&1 == 1 {
+			subtreeRoot = hasher.HashChildren(proof[i], subtreeRoot)
+			grownSubtreeRoot = hasher.HashChildren(proof[i], grownSubtreeRoot)
+			i++
+			// Otherwise, it's a right sibling, but only as long as we're below
+			// forkLevel, as there are no right siblings above it.
+		} else if lvl < forkLevel {
+			grownSubtreeRoot = hasher.HashChildren(grownSubtreeRoot, proof[i])
+			i++
+		}
+	}
+	return subtreeRoot, grownSubtreeRoot, proof[i:]
 }
 
 // decompInclProof breaks down inclusion proof for a leaf at the specified


### PR DESCRIPTION
Towards #225.

This PR introduces `VerifySubtreeConsistency`. The implementation is a bit different from the current `VerifyConsistency` implementation, hence the PR length. However I believe that this one is easier to follow, and closer to specs:
  - First we reconstruct the original and the grown subtree roots
  - Then, we treat the rest of the proof as an inclusion proof

This is how I've explained things in the design doc as well.

I've got two other candidate implementations, that are more similar to the current one, but I find them quite hard to follow. The complexity is around figuring out which proof nodes we need to recompute the subtree root hash. For regular consistency proofs, breaking the proof down where the path of |end-1| and |size-1| is enough. It's a bit more complex when it comes to subtrees:
 - [This](https://github.com/transparency-dev/merkle/compare/main...phbnf:merkle:vercons?expand=1) implementation uses a `decompSubtreeProof` function, but I still find quite it hard to follow.
 - [That](https://github.com/transparency-dev/merkle/compare/main...phbnf:merkle:vercons-masks?expand=1) implementation uses masking, which isn't that straight forward at first sight.

I ran a few benchmarks, and did not find any significant performance difference between these implementations.

I've also gone maximalist on comments, and I'm happy to remove some.
I'm sure that either implementation could be improved, but since I'd rather that we agree on a direction first.