### PR TITLE
Subtree consistency proof verification

### DIFF
--- a/proof/verify.go
+++ b/proof/verify.go
@@ -139,15 +139,18 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
 	// inclusion proof for entry |size1-1| in a tree of size |size2|.
 
-	// Verify the first root.
-	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-	hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
-	hash1 = chainBorderRight(hasher, hash1, proof[inner:])
-	if err := verifyMatch(hash1, root1); err != nil {
-		return nil, err
+	// Verify the first root, if included in the proof.
+	if start != 0 {
+		mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
+		hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
+		hash1 = chainBorderRight(hasher, hash1, proof[inner:])
+		if err := verifyMatch(hash1, root1); err != nil {
+			return nil, err
+		}
 	}
 
 	// Verify the second root.
+	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
 	hash2 := chainInner(hasher, seed, proof[:inner], mask)
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -218,13 +218,14 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
 	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
+	mask := (end - 1) >> uint(shift) // Start chaining from level |shift|.
+
 	// If the argument subtree is not full, the proof includes somes nodes that
 	// belong to the subtree. We must verify that these nodes chain correctly to
 	// the argument subtree root.
 	if pStart == 1 {
 		subInner, innerIdx, borderEnd := decompSubtreeProof(start, end, size, border)
-		rightMask := (end - 1) >> uint(shift)
-		hash1 := chainInnerRight(hasher, seed, proof[:subInner], rightMask)
+		hash1 := chainInnerRight(hasher, seed, proof[:subInner], mask)
 		hash1 = chainBorderRight(hasher, hash1, proof[innerIdx:borderEnd])
 		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
@@ -232,8 +233,7 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	}
 
 	// Verify the second root.
-	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
-	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
+	hash2 := chainInner(hasher, seed, proof[:inner], mask)
 	// Then, chain the upper part of the proof.
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -250,16 +250,32 @@ func decompInclProof(index, size uint64) (int, int) {
 	return inner, border
 }
 
-// decompSubtreeProof returns the exact proof slice indices (subInner, inner,
-// and inner+subBorder) needed to reconstruct hash1.
+// decompSubtreeProof computes the exact proof slice indices needed to reconstruct
+// the [start, end) subtree root (hash1):
+//   - subInner: end index of inner proof hashes inside the subtree (proof[:subInner])
+//   - inner: start index of border proof hashes (proof[inner:])
+//   - inner+subBorder: end index of border proof hashes inside the subtree
 func decompSubtreeProof(start, end, size uint64, border int) (int, int, int) {
+	// xor trims the common prefix between the first and last entry. The bit len
+	// of the result is the height of the subtree.
 	h := bits.Len64((end - 1) ^ start)
+	// Using a similar technique, we compute where paths to leaves |end-1| and
+	// |size-1| diverge.
 	forkLevel := bits.Len64((end - 1) ^ (size - 1))
+	// Height of the rightmost full subtree within the argument subtree.
+	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
 
+	// Number of inner proof nodes from level |shift| up to subtree height |h|
+	// (clamped at |forkLevel|) that belong inside the [start, end) subtree.
 	subInner := min(h, forkLevel) - shift
+	// Total number of inner proof nodes between level |shift| and |forkLevel|.
 	inner := forkLevel - shift
+	// Number of border proof nodes above |forkLevel| and below subtree height |h|
+	// that belong inside the [start, end) subtree.
 	subBorder := max(0, border-bits.OnesCount64((end-1)>>uint(h)))
+	// The proof slice indices needed to reconstruct hash1 are [0:subInner] for inner
+	// chaining and [inner:inner+subBorder] for border chaining.
 	return subInner, inner, inner + subBorder
 }
 

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -168,9 +168,9 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 }
 
 func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
-	// If the right end of the subtree overlaps with the right end of the parent
-	// tree, the proof allows reconstructing the tree root directly from the
-	// argument subtree root |subRoot|.
+	// If the right end of the subtree is also the right end of the parent tree,
+	// the proof allows reconstructing the tree root directly from the argument
+	// subtree root |subRoot|.
 	if end == size {
 		// Find the root of the subtree.
 		// xor trims the common prefix between the first and last entry. The bit len
@@ -187,27 +187,27 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	}
 
 	// Otherwise, we need to:
-	//   - Verify that nodes in the proof that belongs to the subtree are consistent
+	//   - Verify that nodes in the proof that belong to the subtree are consistent
 	//     with the argument subtree root |subRoot|.
-	//   - Reconstruct the parent tree root from the the argument subtree root
+	//   - Reconstruct the parent tree root from the argument subtree root
 	//     grown into a subtree of the parent tree of size |size|.
 	//
 	// Split the proof in two, where paths to leaves |end-1| and |size-1| diverge.
 	forkLevel, border := decompInclProof(end-1, size)
-	// Height of the rightmost full subtree within the argument subtree.
+	// Height of the rightmost perfect subtree within the argument subtree.
 	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
-	// Number of level between the root of that subtree and the end the the first
+	// Number of levels between the root of that subtree and the end of the first
 	// part of the proof.
 	inner := forkLevel - shift // Note: shift < inner if end < size.
 
 	// The first node of the proof is the root of the rightmost subtree within
 	// the argument subtree.
 	seed, pStart := proof[0], 1
-	// Unless the argument subtree is full, in which case that rightmost subtree
-	// is the argument subtree itself. Its root is not included in the proof
-	// since a client verifying a subtree inclusion proof is expected to already
-	// know what the root of that subtree is.
+	// Unless the argument subtree is perfect, in which case that rightmost
+	// subtree is the argument subtree itself. Its root is not included in the
+	// proof since a client verifying a subtree inclusion proof is expected to
+	// already know what the root of that subtree is.
 	if (end - start) == 1<<uint(shift) {
 		seed, pStart = subRoot, 0
 	}
@@ -220,13 +220,13 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 
 	mask := (end - 1) >> uint(shift) // Start chaining from level |shift|.
 
-	// If the argument subtree is not full, the proof includes somes nodes that
+	// If the argument subtree is not perfect, the proof includes some nodes that
 	// belong to the subtree. We must verify that these nodes chain correctly to
 	// the argument subtree root.
 	if pStart == 1 {
-		subInner, innerIdx, borderEnd := decompSubtreeProof(start, end, size, border)
-		hash1 := chainInnerRight(hasher, seed, proof[:subInner], mask)
-		hash1 = chainBorderRight(hasher, hash1, proof[innerIdx:borderEnd])
+		subInner, subBorder := decompSubtreeProof(start, end, size, border, proof)
+		hash1 := chainInnerRight(hasher, seed, subInner, mask)
+		hash1 = chainBorderRight(hasher, hash1, subBorder)
 		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
 		}
@@ -254,44 +254,43 @@ func decompInclProof(index, size uint64) (int, int) {
 }
 
 // decompSubtreeProof computes the exact proof slice indices needed to
-// reconstruct the [start, end) subtree root
-//   - subInner: end index of inner proof hashes inside the subtree
-//     (proof[:subInner]), regardless of the size of the parent tree.
-//     These nodes can be left or right siblings depending on the level at
-//     which they are used in the proof. Only left siblings are required to
-//     reconstruct the subtree root.
-//   - inner: end index of inner proof hashes inside the tree, and potentially
-//     outside of the subtree. It is also the start index of border proof
-//     hashes (proof[inner:]). Border proof hashes are left siblings only.
-//     There's one per level and they can be inside or outside of the subtree.
-//   - inner+subBorder: end index of border proof hashes inside the subtree.
-//     (proof[inner:subBorderEnd]). These nodes are left siblings only.
-func decompSubtreeProof(start, end, size uint64, border int) (subInner int, inner int, subBorderEnd int) {
+// reconstruct the [start, end) subtree root.
+//   - proof[0:subInner]: inner proof hashes under the subtree root node
+//     in a tree of size |end| or |size|. These nodes can be inside or outside
+//     of the subtree, and left or right siblings depending on the level at
+//     which they are used in the proof. Only left siblings (except possibly
+//     the first node) are required to reconstruct the subtree root hash, and
+//     right siblings can be ignored.
+//   - proof[inner:inner+subBorder]: border proof hashes, inside the subtree.
+//     These nodes are left siblings only, and there's one hash per level.
+func decompSubtreeProof(start, end, size uint64, border int, proof [][]byte) (subInnerProof [][]byte, subBorderProof [][]byte) {
 	// xor trims the common prefix between the first and last entry. The bit len
 	// of the result is the height of the subtree.
 	h := bits.Len64((end - 1) ^ start)
 	// Using a similar technique, we compute where paths to leaves |end-1| and
 	// |size-1| diverge.
 	forkLevel := bits.Len64((end - 1) ^ (size - 1))
-	// Height of the rightmost full subtree within the argument subtree.
+	// Height of the rightmost perfect subtree within the argument subtree.
 	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
 
 	// Number of inner proof nodes from level |shift| up to subtree height |h|
 	// (clamped at |forkLevel|) that belong inside the [start, end) subtree.
 	// We take the minimum between h and forkLevel to make sure that subInner
-	// isn't higher than the subtree root. Substract shift since the proof
+	// isn't higher than the subtree root. Subtract shift since the proof
 	// starts at this level.
-	subInner = min(h, forkLevel) - shift
+	subInner := min(h, forkLevel) - shift
 	// Total number of inner proof nodes between level |shift| and |forkLevel|.
-	inner = forkLevel - shift
+	// It delimits the end of the inner proof nodes, and the beginning of the
+	// border nodes.
+	inner := forkLevel - shift
 	// Number of border proof nodes above |forkLevel| and below subtree height |h|
 	// that belong inside the [start, end) subtree. Use max as the border proof
-	// might not include any node that belong to the subtree.
+	// might not include any nodes that belong to the subtree.
 	subBorder := max(0, border-bits.OnesCount64((end-1)>>uint(h)))
 	// The proof slice indices needed to reconstruct hash1 are [0:subInner] for
 	// inner-right chaining and [inner:inner+subBorder] for border chaining.
-	return subInner, inner, inner + subBorder
+	return proof[0:subInner], proof[inner : inner+subBorder]
 }
 
 func innerProofSize(index, size uint64) int {

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -222,20 +222,10 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// belong to the subtree. We must verify that these nodes chain correctly to
 	// the argument subtree root.
 	if pStart == 1 {
+		subInner, innerIdx, borderEnd := decompSubtreeProof(start, end, size, border)
 		rightMask := (end - 1) >> uint(shift)
-		leftMask := start >> uint(shift)
-		// Clamp the proof such that it only includes nodes inside the subtree.
-		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
-		// First, partially reconstruct the subtree root (hash1) by chaining left siblings
-		// from the inner part of the proof, and inside the subtree.
-		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
-
-		// Then, hash the remaining border nodes that belong to the subtree.
-		if border > 0 {
-			// Only take border nodes that are to the right of |start| (inside the subtree).
-			k := border - bits.OnesCount64(start>>uint(forkLevel))
-			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
-		}
+		hash1 := chainInnerRight(hasher, seed, proof[:subInner], rightMask)
+		hash1 = chainBorderRight(hasher, hash1, proof[innerIdx:borderEnd])
 		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
 		}
@@ -258,6 +248,19 @@ func decompInclProof(index, size uint64) (int, int) {
 	inner := innerProofSize(index, size)
 	border := bits.OnesCount64(index >> uint(inner))
 	return inner, border
+}
+
+// decompSubtreeProof returns the exact proof slice indices (subInner, inner,
+// and inner+subBorder) needed to reconstruct hash1.
+func decompSubtreeProof(start, end, size uint64, border int) (int, int, int) {
+	h := bits.Len64((end - 1) ^ start)
+	forkLevel := bits.Len64((end - 1) ^ (size - 1))
+	shift := bits.TrailingZeros64(end - start)
+
+	subInner := min(h, forkLevel) - shift
+	inner := forkLevel - shift
+	subBorder := max(0, border-bits.OnesCount64((end-1)>>uint(h)))
+	return subInner, inner, inner + subBorder
 }
 
 func innerProofSize(index, size uint64) int {

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -139,13 +139,16 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	return rootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
 }
 
-// RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
-// of the given size, provided with a subtree [start, end), its root and a
-// consistency proof.
+// RootFromSubtreeConsistencyProof calculates the expected root hash for a
+// parent tree of the given size, from a subtree [start, end) with its root and
+// a consistency proof.
+//
 // It requires:
 //   - 0 <= start < end <= size.
 //   - start to be a multiple of the smallest power of two greater than or equal to
 //     (end - start)
+//
+// Returns an error if the proof does not hash to the provided subtree root.
 func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
 	err := isSubtreeValid(start, end)
 	switch {
@@ -161,28 +164,21 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
-	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, subRoot)
 }
 
-func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1 []byte) ([]byte, error) {
-	err := isSubtreeValid(start, end)
-	switch {
-	case err != nil:
-		return nil, fmt.Errorf("subtree invalid: %v", err)
-	case size < end:
-		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
-	case start == 0 && size == end:
-		if len(proof) > 0 {
-			return nil, errors.New("start=0 and end=size, but proof is not empty")
-		}
-		return root1, nil
-	case len(proof) == 0:
-		return nil, errors.New("empty proof")
-	// If the right end of the subtree overlaps with the right end of the tree,
-	// compute the tree root directly.
-	case end == size:
+func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
+	// If the right end of the subtree overlaps with the right end of the parent
+	// tree, the proof allows reconstructing the tree root directly from the
+	// argument subtree root |subRoot|.
+	if end == size {
+		// Find the root of the subtree.
+		// xor trims the common prefix between the first and last entry. The bit len
+		// of the result is the height of the subtree.
 		level := bits.Len64((end - 1) ^ start) // Height of the subtree.
 		index := start >> level
+		// To reconstruct the root from the subtree root, we need one left sibling
+		// node for each level where the subtree's ancestor is a right child.
 		want := bits.OnesCount64(index)
 		if got := len(proof); got != want {
 			return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
@@ -190,13 +186,28 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 		return chainBorderRight(hasher, subRoot, proof), nil
 	}
 
-	inner, border := decompInclProof(end-1, size)
+	// Otherwise, we need to:
+	//   - Verify that nodes in the proof that belongs to the subtree are consistent
+	//     with the argument subtree root |subRoot|.
+	//   - Reconstruct the parent tree root from the the argument subtree root
+	//     grown into a subtree of the parent tree of size |size|.
+	//
+	// Split the proof in two, where paths to leaves |end-1| and |size-1| diverge.
+	forkLevel, border := decompInclProof(end-1, size)
+	// Height of the rightmost full subtree within the argument subtree.
+	// The proof starts at this level.
 	shift := bits.TrailingZeros64(end - start)
-	inner -= shift // Note: shift < inner if end < size.
+	// Number of level between the root of that subtree and the end the the first
+	// part of the proof.
+	inner := forkLevel - shift // Note: shift < inner if end < size.
 
-	// The proof includes the root hash for the sub-tree of size 2^shift.
+	// The first node of the proof is the root of the rightmost subtree within
+	// the argument subtree.
 	seed, pStart := proof[0], 1
-	// Unless the subtree is that very 2^shift.
+	// Unless the argument subtree is full, in which case that rightmost subtree
+	// is the argument subtree itself. Its root is not included in the proof
+	// since a client verifying a subtree inclusion proof is expected to already
+	// know what the root of that subtree is.
 	if (end - start) == 1<<uint(shift) {
 		seed, pStart = subRoot, 0
 	}
@@ -207,14 +218,22 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
 	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
-	// Verify the first root, if included in the proof.
-	if start != 0 {
+	// If the argument subtree is not full, the proof includes somes nodes that
+	// belong to the subtree. We must verify that these nodes chain correctly to
+	// the argument subtree root.
+	if pStart == 1 {
 		rightMask := (end - 1) >> uint(shift)
 		leftMask := start >> uint(shift)
+		// Clamp the proof such that it only includes nodes inside the subtree.
 		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
+		// First, partially reconstruct the subtree root (hash1) by chaining left siblings
+		// from the inner part of the proof, and inside the subtree.
 		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
+
+		// Then, hash the remaining border nodes that belong to the subtree.
 		if border > 0 {
-			k := border - bits.OnesCount64(start>>uint(inner))
+			// Only take border nodes that are to the right of |start| (inside the subtree).
+			k := border - bits.OnesCount64(start>>uint(forkLevel))
 			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
 		}
 		if err := verifyMatch(hash1, subRoot); err != nil {
@@ -225,6 +244,7 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	// Verify the second root.
 	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
 	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
+	// Then, chain the upper part of the proof.
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil
 }
@@ -241,6 +261,8 @@ func decompInclProof(index, size uint64) (int, int) {
 }
 
 func innerProofSize(index, size uint64) int {
+	// Height of the first node where the paths of leaves at |index| and |size-1|
+	// diverge.
 	return bits.Len64(index ^ (size - 1))
 }
 

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -110,12 +110,12 @@ func VerifyConsistency(hasher merkle.LogHasher, size1, size2 uint64, proof [][]b
 //   - 0 <= start < end <= size.
 //   - start to be a multiple of the smallest power of two greater than or equal to
 //     (end - start)
-func VerifySubtreeConsistency(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1, root2 []byte) error {
-	hash2, err := RootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+func VerifySubtreeConsistency(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot, parentRoot []byte) error {
+	hash2, err := RootFromSubtreeConsistencyProof(hasher, start, end, size, proof, subRoot)
 	if err != nil {
 		return err
 	}
-	return verifyMatch(hash2, root2)
+	return verifyMatch(hash2, parentRoot)
 }
 
 // RootFromConsistencyProof calculates the expected root hash for a tree of the
@@ -234,7 +234,6 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 
 	// Verify the second root.
 	hash2 := chainInner(hasher, seed, proof[:inner], mask)
-	// Then, chain the upper part of the proof.
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil
 }
@@ -242,20 +241,32 @@ func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 // decompInclProof breaks down inclusion proof for a leaf at the specified
 // |index| in a tree of the specified |size| into 2 components. The splitting
 // point between them is where paths to leaves |index| and |size-1| diverge.
-// Returns lengths of the bottom and upper proof parts correspondingly. The sum
+// Returns lengths of the inner and border proof parts correspondingly. The sum
 // of the two determines the correct length of the inclusion proof.
+//
+// Inner nodes are left or right siblings depending on the level they are used
+// in the proof. There can be multiple nodes per level.
+// Border nodes are left siblings only. There's only one node per level.
 func decompInclProof(index, size uint64) (int, int) {
 	inner := innerProofSize(index, size)
 	border := bits.OnesCount64(index >> uint(inner))
 	return inner, border
 }
 
-// decompSubtreeProof computes the exact proof slice indices needed to reconstruct
-// the [start, end) subtree root (hash1):
-//   - subInner: end index of inner proof hashes inside the subtree (proof[:subInner])
-//   - inner: start index of border proof hashes (proof[inner:])
-//   - inner+subBorder: end index of border proof hashes inside the subtree
-func decompSubtreeProof(start, end, size uint64, border int) (int, int, int) {
+// decompSubtreeProof computes the exact proof slice indices needed to
+// reconstruct the [start, end) subtree root
+//   - subInner: end index of inner proof hashes inside the subtree
+//     (proof[:subInner]), regardless of the size of the parent tree.
+//     These nodes can be left or right siblings depending on the level at
+//     which they are used in the proof. Only left siblings are required to
+//     reconstruct the subtree root.
+//   - inner: end index of inner proof hashes inside the tree, and potentially
+//     outside of the subtree. It is also the start index of border proof
+//     hashes (proof[inner:]). Border proof hashes are left siblings only.
+//     There's one per level and they can be inside or outside of the subtree.
+//   - inner+subBorder: end index of border proof hashes inside the subtree.
+//     (proof[inner:subBorderEnd]). These nodes are left siblings only.
+func decompSubtreeProof(start, end, size uint64, border int) (subInner int, inner int, subBorderEnd int) {
 	// xor trims the common prefix between the first and last entry. The bit len
 	// of the result is the height of the subtree.
 	h := bits.Len64((end - 1) ^ start)
@@ -268,14 +279,18 @@ func decompSubtreeProof(start, end, size uint64, border int) (int, int, int) {
 
 	// Number of inner proof nodes from level |shift| up to subtree height |h|
 	// (clamped at |forkLevel|) that belong inside the [start, end) subtree.
-	subInner := min(h, forkLevel) - shift
+	// We take the minimum between h and forkLevel to make sure that subInner
+	// isn't higher than the subtree root. Substract shift since the proof
+	// starts at this level.
+	subInner = min(h, forkLevel) - shift
 	// Total number of inner proof nodes between level |shift| and |forkLevel|.
-	inner := forkLevel - shift
+	inner = forkLevel - shift
 	// Number of border proof nodes above |forkLevel| and below subtree height |h|
-	// that belong inside the [start, end) subtree.
+	// that belong inside the [start, end) subtree. Use max as the border proof
+	// might not include any node that belong to the subtree.
 	subBorder := max(0, border-bits.OnesCount64((end-1)>>uint(h)))
-	// The proof slice indices needed to reconstruct hash1 are [0:subInner] for inner
-	// chaining and [inner:inner+subBorder] for border chaining.
+	// The proof slice indices needed to reconstruct hash1 are [0:subInner] for
+	// inner-right chaining and [inner:inner+subBorder] for border chaining.
 	return subInner, inner, inner + subBorder
 }
 

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -104,6 +104,20 @@ func VerifyConsistency(hasher merkle.LogHasher, size1, size2 uint64, proof [][]b
 	return verifyMatch(hash2, root2)
 }
 
+// VerifySubtreeConsistency checks that the passed-in subtree consistency proof
+// is valid between the passed in subtree indices and parent tree size, with
+// respect to the corresponding subtree root node hash. It Requires:
+//   - 0 <= start < end <= size.
+//   - start to be a multiple of the smallest power of two greater than or equal to
+//     (end - start)
+func VerifySubtreeConsistency(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1, root2 []byte) error {
+	hash2, err := RootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+	if err != nil {
+		return err
+	}
+	return verifyMatch(hash2, root2)
+}
+
 // RootFromConsistencyProof calculates the expected root hash for a tree of the
 // given size2, provided a tree of size1 with root1, and a consistency proof.
 // Requires 0 < size1 <= size2.
@@ -122,36 +136,80 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
+	return RootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
+}
 
-	inner, border := decompInclProof(size1-1, size2)
-	shift := bits.TrailingZeros64(size1)
-	inner -= shift // Note: shift < inner if size1 < size2.
+// RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
+// of the given size, provided with a subtree [start, end), its root and a
+// consistency proof.
+// It requires:
+//   - 0 <= start < end <= size.
+//   - start to be a multiple of the smallest power of two greater than or equal to
+//     (end - start)
+func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte) ([]byte, error) {
+	err := isSubtreeValid(start, end)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("subtree invalid: %v", err)
+	case size < end:
+		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
+	case start == 0 && size == end:
+		if len(proof) > 0 {
+			return nil, errors.New("start=0 and end=size, but proof is not empty")
+		}
+		return subRoot, nil
+	case len(proof) == 0:
+		return nil, errors.New("empty proof")
+	// If the right end of the subtree overlaps with the right end of the tree,
+	// compute the tree root directly.
+	case end == size:
+		level := bits.Len64((end - 1) ^ start) // Height of the subtree.
+		index := start >> level
+		want := bits.OnesCount64(index)
+		if got := len(proof); got != want {
+			return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
+		}
+		return chainBorderRight(hasher, subRoot, proof), nil
+	}
+
+	inner, border := decompInclProof(end-1, size)
+	shift := bits.TrailingZeros64(end - start)
+	inner -= shift // Note: shift < inner if end < size.
 
 	// The proof includes the root hash for the sub-tree of size 2^shift.
-	seed, start := proof[0], 1
-	if size1 == 1<<uint(shift) { // Unless size1 is that very 2^shift.
-		seed, start = root1, 0
+	seed, pStart := proof[0], 1
+	// Unless the subtree is that very 2^shift.
+	if (end - start) == 1<<uint(shift) {
+		seed, pStart = subRoot, 0
 	}
-	if got, want := len(proof), start+inner+border; got != want {
+	if got, want := len(proof), pStart+inner+border; got != want {
 		return nil, fmt.Errorf("wrong proof size %d, want %d", got, want)
 	}
-	proof = proof[start:]
+	proof = proof[pStart:]
 	// Now len(proof) == inner+border, and proof is effectively a suffix of
-	// inclusion proof for entry |size1-1| in a tree of size |size2|.
+	// the inclusion proof for entry |end-1| in a tree of size |size|.
 
 	// Verify the first root, if included in the proof.
 	if start != 0 {
-		mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-		hash1 := chainInnerRight(hasher, seed, proof[:inner], mask)
-		hash1 = chainBorderRight(hasher, hash1, proof[inner:])
-		if err := verifyMatch(hash1, root1); err != nil {
+		rightMask := (end - 1) >> uint(shift)
+		leftMask := start >> uint(shift)
+		clampedLen := bits.Len64(rightMask ^ leftMask)
+		if clampedLen > inner {
+			clampedLen = inner
+		}
+		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
+		if border > 0 {
+			k := border - bits.OnesCount64(start>>uint(inner))
+			hash1 = chainBorderRight(hasher, hash1, proof[inner:inner+k])
+		}
+		if err := verifyMatch(hash1, subRoot); err != nil {
 			return nil, err
 		}
 	}
 
 	// Verify the second root.
-	mask := (size1 - 1) >> uint(shift) // Start chaining from level |shift|.
-	hash2 := chainInner(hasher, seed, proof[:inner], mask)
+	rightMask := (end - 1) >> uint(shift) // Start chaining from level |shift|
+	hash2 := chainInner(hasher, seed, proof[:inner], rightMask)
 	hash2 = chainBorderRight(hasher, hash2, proof[inner:])
 	return hash2, nil
 }

--- a/proof/verify.go
+++ b/proof/verify.go
@@ -136,7 +136,7 @@ func RootFromConsistencyProof(hasher merkle.LogHasher, size1, size2 uint64, proo
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	}
-	return RootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
+	return rootFromSubtreeConsistencyProof(hasher, 0, size1, size2, proof, root1)
 }
 
 // RootFromSubtreeConsistencyProof calculates the expected root hash for a tree
@@ -158,6 +158,24 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 			return nil, errors.New("start=0 and end=size, but proof is not empty")
 		}
 		return subRoot, nil
+	case len(proof) == 0:
+		return nil, errors.New("empty proof")
+	}
+	return rootFromSubtreeConsistencyProof(hasher, start, end, size, proof, root1)
+}
+
+func rootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, root1 []byte) ([]byte, error) {
+	err := isSubtreeValid(start, end)
+	switch {
+	case err != nil:
+		return nil, fmt.Errorf("subtree invalid: %v", err)
+	case size < end:
+		return nil, fmt.Errorf("size (%d) < end (%d)", size, end)
+	case start == 0 && size == end:
+		if len(proof) > 0 {
+			return nil, errors.New("start=0 and end=size, but proof is not empty")
+		}
+		return root1, nil
 	case len(proof) == 0:
 		return nil, errors.New("empty proof")
 	// If the right end of the subtree overlaps with the right end of the tree,
@@ -193,10 +211,7 @@ func RootFromSubtreeConsistencyProof(hasher merkle.LogHasher, start, end, size u
 	if start != 0 {
 		rightMask := (end - 1) >> uint(shift)
 		leftMask := start >> uint(shift)
-		clampedLen := bits.Len64(rightMask ^ leftMask)
-		if clampedLen > inner {
-			clampedLen = inner
-		}
+		clampedLen := min(bits.Len64(rightMask^leftMask), inner)
 		hash1 := chainInnerRight(hasher, seed, proof[:clampedLen], rightMask)
 		if border > 0 {
 			k := border - bits.OnesCount64(start>>uint(inner))


### PR DESCRIPTION
Towards #225.

This PR introduces VerifySubtreeConsistency. The implementation is a bit different from the current VerifyConsistency implementation, hence the PR length. However I believe that this one is easier to follow, and closer to specs: