### PR TITLE
Subtree consistency tests for subtrees starting at 0

### DIFF
--- a/cmd/proofgen/main.go
+++ b/cmd/proofgen/main.go
@@ -531,8 +531,10 @@ func consistencyProbes(rootDir string) error {
 		return err
 	}
 
-	if err := staticConsistencyProbes(staticDir); err != nil {
-		return err
+	for _, p := range staticConsistencyProbes() {
+		if err := writeConsistencyProbe(staticDir, p); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -604,13 +606,13 @@ func corruptedConsistencyProbes(dir string, size1, size2 uint64, proof [][]byte,
 	return nil
 }
 
-func staticConsistencyProbes(dir string) error {
+func staticConsistencyProbes() []consistencyProbe {
 	root1 := []byte("don't care 1")
 	root2 := []byte("don't care 2")
 	proof1 := [][]byte{}
 	proof2 := [][]byte{sha256EmptyTreeHash}
 
-	tests := []consistencyProbe{
+	return []consistencyProbe{
 		{0, 0, root1, root2, proof1, "sizes are equal (zero) but roots are not", true},
 		{1, 1, root1, root2, proof1, "sizes are equal (one) but roots are not", true},
 		{0, 0, root1, root1, proof1, "sizes are equal (zero) and proof is empty", true},
@@ -632,9 +634,80 @@ func staticConsistencyProbes(dir string) error {
 		{0, 1, sha256EmptyTreeHash, root2, proof1, "size1 is zero and size2 is not zero", true},
 		{0, 1, sha256EmptyTreeHash, sha256EmptyTreeHash, proof2, "consistency check on empty tree (size1 is zero) is useless", true},
 	}
+}
 
-	for _, p := range tests {
-		if err := writeConsistencyProbe(dir, p); err != nil {
+func writeConsistencyProbe(dir string, probe consistencyProbe) error {
+	fn := fileName(probe.Desc)
+
+	probeJson, err := json.MarshalIndent(probe, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling probe: %s", err)
+	}
+
+	fileLocation := filepath.Join(dir, fn)
+	if err := os.WriteFile(fileLocation, probeJson, 0644); err != nil {
+		return fmt.Errorf("writing probe: %s: %s", fn, err)
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Subtree Consistency Proofs
+// =============================================================================
+
+// subtreeConsistencyProbe is a parameter set for subtree consistency proof
+// verification.
+type subtreeConsistencyProbe struct {
+	Start uint64   `json:"start"`
+	End   uint64   `json:"end"`
+	Size  uint64   `json:"size"`
+	Root1 []byte   `json:"root1"`
+	Root2 []byte   `json:"root2"`
+	Proof [][]byte `json:"proof"`
+
+	Desc      string `json:"desc"`
+	WantError bool   `json:"wantErr"`
+}
+
+func subtreeConsistencyProbes(rootDir string) error {
+	for i, p := range consistencyProofs {
+		dir := filepath.Join(rootDir, strconv.Itoa(i))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+
+		if err := corruptedSubtreeConsistencyProbes(dir, p.size1, p.size2, p.proof,
+			roots[p.size1-1], roots[p.size2-1]); err != nil {
+			return fmt.Errorf("write subtree consistency test data: %s", err)
+		}
+	}
+
+	staticDir := filepath.Join(rootDir, "additional")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		return err
+	}
+
+	if err := staticSubtreeConsistencyProbes(staticDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func corruptedSubtreeConsistencyProbes(dir string, size1, size2 uint64, proof [][]byte, root1, root2 []byte) error {
+	happyPath := subtreeConsistencyProbe{0, size1, size2, root1, root2, proof, "happy path", false}
+	if err := writeSubtreeConsistencyProbe(dir, happyPath); err != nil {
+		return err
+	}
+
+	if len(proof) == 0 {
+		return nil
+	}
+
+	probes := invalidSubtreeConsistencyProof(size1, size2, root1, root2, proof)
+	for _, p := range probes {
+		if err := writeSubtreeConsistencyProbe(dir, p); err != nil {
 			return err
 		}
 	}
@@ -642,7 +715,54 @@ func staticConsistencyProbes(dir string) error {
 	return nil
 }
 
-func writeConsistencyProbe(dir string, probe consistencyProbe) error {
+func invalidSubtreeConsistencyProof(size1, size2 uint64, root1, root2 []byte, proof [][]byte) []subtreeConsistencyProbe {
+	cProbes := invalidConsistencyProof(size1, size2, root1, root2, proof)
+	ret := make([]subtreeConsistencyProbe, 0, len(cProbes)+1)
+	for _, p := range cProbes {
+		ret = append(ret, subtreeConsistencyProbe{
+			Start:     0,
+			End:       p.Size1,
+			Size:      p.Size2,
+			Root1:     p.Root1,
+			Root2:     p.Root2,
+			Proof:     p.Proof,
+			Desc:      p.Desc,
+			WantError: p.WantError,
+		})
+	}
+	ret = append(ret, subtreeConsistencyProbe{
+		Start:     1,
+		End:       15,
+		Size:      15,
+		Root1:     root1,
+		Root2:     root2,
+		Proof:     proof,
+		Desc:      "invalid subtree",
+		WantError: true,
+	})
+	return ret
+}
+
+func staticSubtreeConsistencyProbes(dir string) error {
+	for _, p := range staticConsistencyProbes() {
+		sp := subtreeConsistencyProbe{
+			Start:     0,
+			End:       p.Size1,
+			Size:      p.Size2,
+			Root1:     p.Root1,
+			Root2:     p.Root2,
+			Proof:     p.Proof,
+			Desc:      p.Desc,
+			WantError: p.WantError,
+		}
+		if err := writeSubtreeConsistencyProbe(dir, sp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSubtreeConsistencyProbe(dir string, probe subtreeConsistencyProbe) error {
 	fn := fileName(probe.Desc)
 
 	probeJson, err := json.MarshalIndent(probe, "", "  ")
@@ -709,5 +829,10 @@ func main() {
 	consistencyDir := "testdata/consistency"
 	if err := consistencyProbes(consistencyDir); err != nil {
 		log.Fatalf("writing consistency test data: %s", err)
+	}
+
+	subtreeConsistencyDir := "testdata/subtreeconsistency"
+	if err := subtreeConsistencyProbes(subtreeConsistencyDir); err != nil {
+		log.Fatalf("writing subtree consistency test data: %s", err)
 	}
 }

--- a/proof/verify_test.go
+++ b/proof/verify_test.go
@@ -64,6 +64,20 @@ type consistencyProbe struct {
 	WantError bool   `json:"wantErr"`
 }
 
+// subtreeConsistencyProbe is a parameter set for subtree consistency proof
+// verification.
+type subtreeConsistencyProbe struct {
+	Start uint64   `json:"start"`
+	End   uint64   `json:"end"`
+	Size  uint64   `json:"size"`
+	Root1 []byte   `json:"root1"`
+	Root2 []byte   `json:"root2"`
+	Proof [][]byte `json:"proof"`
+
+	Desc      string `json:"desc"`
+	WantError bool   `json:"wantErr"`
+}
+
 func TestVerifyInclusionProbes(t *testing.T) {
 	var probes []inclusionProbe
 
@@ -217,5 +231,57 @@ func TestVerifyConsistencyProbes(t *testing.T) {
 
 	if len(wrong) > 0 {
 		t.Errorf("errors verifying consistency probes: \n%d out of %d failures \nError messages: \n%s", len(wrong), len(probes), strings.Join(wrong, "\n"))
+	}
+}
+
+func TestVerifySubtreeConsistencyProbes(t *testing.T) {
+	var probes []subtreeConsistencyProbe
+
+	if err := filepath.WalkDir("../testdata/subtreeconsistency", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(d.Name()) != ".json" {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		var probe subtreeConsistencyProbe
+		if err := json.Unmarshal(data, &probe); err != nil {
+			return fmt.Errorf("failed to parse subtree consistency probe json: %s", err)
+		}
+
+		probes = append(probes, probe)
+
+		return nil
+	}); err != nil {
+		t.Errorf("failed to read subtree consistency probes: %s", err)
+	}
+
+	var wrong []string
+	for _, p := range probes {
+		err := VerifySubtreeConsistency(rfc6962.DefaultHasher, p.Start, p.End, p.Size, p.Proof, p.Root1, p.Root2)
+		if p.WantError && err == nil {
+			wrong = append(wrong, fmt.Sprintf("expected error but didn't get one: %s", p.Desc))
+			continue
+		}
+
+		if !p.WantError && err != nil {
+			wrong = append(wrong, fmt.Sprintf("unexpected error: %s, %s", p.Desc, err))
+			continue
+		}
+	}
+
+	if len(wrong) > 0 {
+		t.Errorf("errors verifying subtree consistency probes: \n%d out of %d failures \nError messages: \n%s", len(wrong), len(probes), strings.Join(wrong, "\n"))
 	}
 }

--- a/testdata/subtreeconsistency/0/happy-path.json
+++ b/testdata/subtreeconsistency/0/happy-path.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "proof": null,
+  "desc": "happy path",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/1/empty-proof.json
+++ b/testdata/subtreeconsistency/1/empty-proof.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [],
+  "desc": "empty proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/happy-path.json
+++ b/testdata/subtreeconsistency/1/happy-path.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "happy path",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/1/invalid-subtree.json
+++ b/testdata/subtreeconsistency/1/invalid-subtree.json
@@ -1,0 +1,14 @@
+{
+  "start": 1,
+  "end": 15,
+  "size": 15,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "invalid subtree",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/modified-proof@0-bit-@4.json
+++ b/testdata/subtreeconsistency/1/modified-proof@0-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "hqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "modified proof@0 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/modified-proof@1-bit-@4.json
+++ b/testdata/subtreeconsistency/1/modified-proof@1-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Twg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "modified proof@1 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/modified-proof@2-bit-@4.json
+++ b/testdata/subtreeconsistency/1/modified-proof@2-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "e0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "modified proof@2 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/preceding-garbage.json
+++ b/testdata/subtreeconsistency/1/preceding-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "",
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "preceding garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/preceding-proof-@0.json
+++ b/testdata/subtreeconsistency/1/preceding-proof-@0.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "preceding proof @0",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/preceding-root1.json
+++ b/testdata/subtreeconsistency/1/preceding-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "preceding root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/preceding-root2.json
+++ b/testdata/subtreeconsistency/1/preceding-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "preceding root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/size1-XOR-@2.json
+++ b/testdata/subtreeconsistency/1/size1-XOR-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 3,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "size1 XOR @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/size1-plus-@1.json
+++ b/testdata/subtreeconsistency/1/size1-plus-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "size1 plus @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/size1-sub-@1.json
+++ b/testdata/subtreeconsistency/1/size1-sub-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "size1 sub @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/size2-div-@2.json
+++ b/testdata/subtreeconsistency/1/size2-div-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 4,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "size2 div @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/size2-mul-@2.json
+++ b/testdata/subtreeconsistency/1/size2-mul-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 16,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "size2 mul @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/swapped-roots.json
+++ b/testdata/subtreeconsistency/1/swapped-roots.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "root2": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "swapped roots",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/trailing-garbage.json
+++ b/testdata/subtreeconsistency/1/trailing-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ=",
+    ""
+  ],
+  "desc": "trailing garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/trailing-root1.json
+++ b/testdata/subtreeconsistency/1/trailing-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ=",
+    "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0="
+  ],
+  "desc": "trailing root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/trailing-root2.json
+++ b/testdata/subtreeconsistency/1/trailing-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ=",
+    "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg="
+  ],
+  "desc": "trailing root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/truncated-proof.json
+++ b/testdata/subtreeconsistency/1/truncated-proof.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4="
+  ],
+  "desc": "truncated proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/wrong-root1.json
+++ b/testdata/subtreeconsistency/1/wrong-root1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "V3JvbmdSb290",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "wrong root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/1/wrong-root2.json
+++ b/testdata/subtreeconsistency/1/wrong-root2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 8,
+  "root1": "bjQLnP+zepicpUTmu3gKLHiQHT+zNzh2hRGjBhevoB0=",
+  "root2": "V3JvbmdSb290",
+  "proof": [
+    "lqKW0iTyhcZ77pPDD4owkVfw2qNdxbh+QQt4YwoJz8c=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "a0eq8p7jwq+a+Im8H7klTavTEXfxYjLdaqsDXKOb9uQ="
+  ],
+  "desc": "wrong root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/empty-proof.json
+++ b/testdata/subtreeconsistency/2/empty-proof.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [],
+  "desc": "empty proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/happy-path.json
+++ b/testdata/subtreeconsistency/2/happy-path.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "happy path",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/2/invalid-subtree.json
+++ b/testdata/subtreeconsistency/2/invalid-subtree.json
@@ -1,0 +1,14 @@
+{
+  "start": 1,
+  "end": 15,
+  "size": 15,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "invalid subtree",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/modified-proof@0-bit-@4.json
+++ b/testdata/subtreeconsistency/2/modified-proof@0-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "HrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@0 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/modified-proof@1-bit-@4.json
+++ b/testdata/subtreeconsistency/2/modified-proof@1-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "2oVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@1 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/modified-proof@2-bit-@4.json
+++ b/testdata/subtreeconsistency/2/modified-proof@2-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "w37kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@2 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/preceding-garbage.json
+++ b/testdata/subtreeconsistency/2/preceding-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/preceding-proof-@0.json
+++ b/testdata/subtreeconsistency/2/preceding-proof-@0.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding proof @0",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/preceding-root1.json
+++ b/testdata/subtreeconsistency/2/preceding-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/preceding-root2.json
+++ b/testdata/subtreeconsistency/2/preceding-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/size1-XOR-@2.json
+++ b/testdata/subtreeconsistency/2/size1-XOR-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 4,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 XOR @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/size1-plus-@1.json
+++ b/testdata/subtreeconsistency/2/size1-plus-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 7,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 plus @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/size1-sub-@1.json
+++ b/testdata/subtreeconsistency/2/size1-sub-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 5,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 sub @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/size2-div-@2.json
+++ b/testdata/subtreeconsistency/2/size2-div-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 4,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size2 div @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/size2-mul-@2.json
+++ b/testdata/subtreeconsistency/2/size2-mul-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 16,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size2 mul @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/swapped-roots.json
+++ b/testdata/subtreeconsistency/2/swapped-roots.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "root2": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "swapped roots",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/trailing-garbage.json
+++ b/testdata/subtreeconsistency/2/trailing-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    ""
+  ],
+  "desc": "trailing garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/trailing-root1.json
+++ b/testdata/subtreeconsistency/2/trailing-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8="
+  ],
+  "desc": "trailing root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/trailing-root2.json
+++ b/testdata/subtreeconsistency/2/trailing-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg="
+  ],
+  "desc": "trailing root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/truncated-proof.json
+++ b/testdata/subtreeconsistency/2/truncated-proof.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA="
+  ],
+  "desc": "truncated proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/wrong-root1.json
+++ b/testdata/subtreeconsistency/2/wrong-root1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "V3JvbmdSb290",
+  "root2": "XcnaeacGWamtVZy3Ad7ZoqudgjqtL0lgz+Nw7/RgQyg=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "wrong root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/2/wrong-root2.json
+++ b/testdata/subtreeconsistency/2/wrong-root2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 8,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "V3JvbmdSb290",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "yoVOoSjtBQtBs1/8G4e46yveRh6eO1WW7Oa51ZdaCuA=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "wrong root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/empty-proof.json
+++ b/testdata/subtreeconsistency/3/empty-proof.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [],
+  "desc": "empty proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/happy-path.json
+++ b/testdata/subtreeconsistency/3/happy-path.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "happy path",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/3/invalid-subtree.json
+++ b/testdata/subtreeconsistency/3/invalid-subtree.json
@@ -1,0 +1,13 @@
+{
+  "start": 1,
+  "end": 15,
+  "size": 15,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "invalid subtree",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/modified-proof@0-bit-@4.json
+++ b/testdata/subtreeconsistency/3/modified-proof@0-bit-@4.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Twg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "modified proof@0 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/modified-proof@1-bit-@4.json
+++ b/testdata/subtreeconsistency/3/modified-proof@1-bit-@4.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "rBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "modified proof@1 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/preceding-garbage.json
+++ b/testdata/subtreeconsistency/3/preceding-garbage.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "preceding garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/preceding-proof-@0.json
+++ b/testdata/subtreeconsistency/3/preceding-proof-@0.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "preceding proof @0",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/preceding-root1.json
+++ b/testdata/subtreeconsistency/3/preceding-root1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "preceding root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/preceding-root2.json
+++ b/testdata/subtreeconsistency/3/preceding-root2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "preceding root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/size1-XOR-@2.json
+++ b/testdata/subtreeconsistency/3/size1-XOR-@2.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "size1 XOR @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/size1-plus-@1.json
+++ b/testdata/subtreeconsistency/3/size1-plus-@1.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 3,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "size1 plus @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/size1-sub-@1.json
+++ b/testdata/subtreeconsistency/3/size1-sub-@1.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "size1 sub @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/size2-div-@2.json
+++ b/testdata/subtreeconsistency/3/size2-div-@2.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 2,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "size2 div @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/size2-mul-@2.json
+++ b/testdata/subtreeconsistency/3/size2-mul-@2.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 10,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "size2 mul @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/swapped-roots.json
+++ b/testdata/subtreeconsistency/3/swapped-roots.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "root2": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "swapped roots",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/trailing-garbage.json
+++ b/testdata/subtreeconsistency/3/trailing-garbage.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms=",
+    ""
+  ],
+  "desc": "trailing garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/trailing-root1.json
+++ b/testdata/subtreeconsistency/3/trailing-root1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms=",
+    "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU="
+  ],
+  "desc": "trailing root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/trailing-root2.json
+++ b/testdata/subtreeconsistency/3/trailing-root2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms=",
+    "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ="
+  ],
+  "desc": "trailing root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/truncated-proof.json
+++ b/testdata/subtreeconsistency/3/truncated-proof.json
@@ -1,0 +1,12 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4="
+  ],
+  "desc": "truncated proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/wrong-root1.json
+++ b/testdata/subtreeconsistency/3/wrong-root1.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "V3JvbmdSb290",
+  "root2": "Tju7H3tHjc/nH7YxYxUZo7yhLJrvyhYSv85ME6hiZNQ=",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "wrong root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/3/wrong-root2.json
+++ b/testdata/subtreeconsistency/3/wrong-root2.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 5,
+  "root1": "+sVCA+fMaWzw38tCySodnbr3CtnmIfS9jZhmLwDjwSU=",
+  "root2": "V3JvbmdSb290",
+  "proof": [
+    "Xwg/ChozygdqlSeYMlgNs+DvRYS9/x9UyKNg9Q3jAx4=",
+    "vBoGQ7EuTS18d5GPROD095qDi2z57FtcKD4fTYhZnms="
+  ],
+  "desc": "wrong root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/empty-proof.json
+++ b/testdata/subtreeconsistency/4/empty-proof.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [],
+  "desc": "empty proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/happy-path.json
+++ b/testdata/subtreeconsistency/4/happy-path.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "happy path",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/4/invalid-subtree.json
+++ b/testdata/subtreeconsistency/4/invalid-subtree.json
@@ -1,0 +1,14 @@
+{
+  "start": 1,
+  "end": 15,
+  "size": 15,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "invalid subtree",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/modified-proof@0-bit-@4.json
+++ b/testdata/subtreeconsistency/4/modified-proof@0-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "HrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@0 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/modified-proof@1-bit-@4.json
+++ b/testdata/subtreeconsistency/4/modified-proof@1-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "oIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@1 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/modified-proof@2-bit-@4.json
+++ b/testdata/subtreeconsistency/4/modified-proof@2-bit-@4.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "w37kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "modified proof@2 bit @4",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/preceding-garbage.json
+++ b/testdata/subtreeconsistency/4/preceding-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/preceding-proof-@0.json
+++ b/testdata/subtreeconsistency/4/preceding-proof-@0.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding proof @0",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/preceding-root1.json
+++ b/testdata/subtreeconsistency/4/preceding-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/preceding-root2.json
+++ b/testdata/subtreeconsistency/4/preceding-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "preceding root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/size1-XOR-@2.json
+++ b/testdata/subtreeconsistency/4/size1-XOR-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 4,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 XOR @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/size1-plus-@1.json
+++ b/testdata/subtreeconsistency/4/size1-plus-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 7,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 plus @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/size1-sub-@1.json
+++ b/testdata/subtreeconsistency/4/size1-sub-@1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 5,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size1 sub @1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/size2-div-@2.json
+++ b/testdata/subtreeconsistency/4/size2-div-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 3,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size2 div @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/size2-mul-@2.json
+++ b/testdata/subtreeconsistency/4/size2-mul-@2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 14,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "size2 mul @2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/swapped-roots.json
+++ b/testdata/subtreeconsistency/4/swapped-roots.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "root2": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "swapped roots",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/trailing-garbage.json
+++ b/testdata/subtreeconsistency/4/trailing-garbage.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    ""
+  ],
+  "desc": "trailing garbage",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/trailing-root1.json
+++ b/testdata/subtreeconsistency/4/trailing-root1.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8="
+  ],
+  "desc": "trailing root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/trailing-root2.json
+++ b/testdata/subtreeconsistency/4/trailing-root2.json
@@ -1,0 +1,15 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc=",
+    "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw="
+  ],
+  "desc": "trailing root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/truncated-proof.json
+++ b/testdata/subtreeconsistency/4/truncated-proof.json
@@ -1,0 +1,13 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8="
+  ],
+  "desc": "truncated proof",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/wrong-root1.json
+++ b/testdata/subtreeconsistency/4/wrong-root1.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "V3JvbmdSb290",
+  "root2": "3bib5AOAnjJXUNPSY814kpwpQreUKjS3fhIslZSnTIw=",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "wrong root1",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/4/wrong-root2.json
+++ b/testdata/subtreeconsistency/4/wrong-root2.json
@@ -1,0 +1,14 @@
+{
+  "start": 0,
+  "end": 6,
+  "size": 7,
+  "root1": "duZ9rbzfHhDht03cYIq9L5jfsW+851J3tSMqEn8gh+8=",
+  "root2": "V3JvbmdSb290",
+  "proof": [
+    "DrxdNDf74tsVi58Sah0RjjCBgQMdCpSfje3t68VY72o=",
+    "sIaT7C5yFZcTBkHoIR5+7cy0wmQTlj7ubB4u0W/7Gl8=",
+    "037kGJdt2VdTwcc4Yrk5j6Kiz5tP8P3+izDNlSCWFLc="
+  ],
+  "desc": "wrong root2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/consistency-check-on-empty-tree-(size1-is-zero)-is-useless.json
+++ b/testdata/subtreeconsistency/additional/consistency-check-on-empty-tree-(size1-is-zero)-is-useless.json
@@ -1,0 +1,12 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 1,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "proof": [
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+  ],
+  "desc": "consistency check on empty tree (size1 is zero) is useless",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/consistency-check-on-empty-tree-size1-is-zero-is-useless.json
+++ b/testdata/subtreeconsistency/additional/consistency-check-on-empty-tree-size1-is-zero-is-useless.json
@@ -1,0 +1,12 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 1,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "proof": [
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+  ],
+  "desc": "consistency check on empty tree (size1 is zero) is useless",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/roots-do-not-match-and-sizes-are-zero.json
+++ b/testdata/subtreeconsistency/additional/roots-do-not-match-and-sizes-are-zero.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "roots do not match and sizes are zero",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/roots-do-not-not-match-and-sizes-are-one.json
+++ b/testdata/subtreeconsistency/additional/roots-do-not-not-match-and-sizes-are-one.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "roots do not not match and sizes are one",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/size1-is-greater-than-size2-again.json
+++ b/testdata/subtreeconsistency/additional/size1-is-greater-than-size2-again.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 2,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "size1 is greater than size2 again",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/size1-is-greater-than-size2.json
+++ b/testdata/subtreeconsistency/additional/size1-is-greater-than-size2.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 0,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "size1 is greater than size2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/size1-is-zero-and-does-not-equal-size2.json
+++ b/testdata/subtreeconsistency/additional/size1-is-zero-and-does-not-equal-size2.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "size1 is zero and does not equal size2",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/size1-is-zero-and-size2-is-not-zero.json
+++ b/testdata/subtreeconsistency/additional/size1-is-zero-and-size2-is-not-zero.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 1,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "size1 is zero and size2 is not zero",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-(one)-and-proof-is-empty.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-(one)-and-proof-is-empty.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAy",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (one) and proof is empty",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-(one)-but-roots-are-not.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-(one)-but-roots-are-not.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (one) but roots are not",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-(zero)-and-proof-is-empty.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-(zero)-and-proof-is-empty.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAx",
+  "proof": [],
+  "desc": "sizes are equal (zero) and proof is empty",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-(zero)-but-roots-are-not.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-(zero)-but-roots-are-not.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (zero) but roots are not",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-one-and-proof-is-empty.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-one-and-proof-is-empty.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAy",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (one) and proof is empty",
+  "wantErr": false
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-one-but-roots-are-not.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-one-but-roots-are-not.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (one) but roots are not",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-zero-and-proof-is-empty.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-zero-and-proof-is-empty.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAx",
+  "proof": [],
+  "desc": "sizes are equal (zero) and proof is empty",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-are-equal-zero-but-roots-are-not.json
+++ b/testdata/subtreeconsistency/additional/sizes-are-equal-zero-but-roots-are-not.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes are equal (zero) but roots are not",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-do-not-watch-and-proof-is-empty.json
+++ b/testdata/subtreeconsistency/additional/sizes-do-not-watch-and-proof-is-empty.json
@@ -1,0 +1,10 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 2,
+  "root1": "ZG9uJ3QgY2FyZSAx",
+  "root2": "ZG9uJ3QgY2FyZSAy",
+  "proof": [],
+  "desc": "sizes do not watch and proof is empty",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-match-but-proof-is-not-empty-and-sizes-are-one.json
+++ b/testdata/subtreeconsistency/additional/sizes-match-but-proof-is-not-empty-and-sizes-are-one.json
@@ -1,0 +1,12 @@
+{
+  "start": 0,
+  "end": 1,
+  "size": 1,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "proof": [
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+  ],
+  "desc": "sizes match but proof is not empty and sizes are one",
+  "wantErr": true
+}

--- a/testdata/subtreeconsistency/additional/sizes-match-but-proof-is-not-empty-and-sizes-are-zero.json
+++ b/testdata/subtreeconsistency/additional/sizes-match-but-proof-is-not-empty-and-sizes-are-zero.json
@@ -1,0 +1,12 @@
+{
+  "start": 0,
+  "end": 0,
+  "size": 0,
+  "root1": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "root2": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+  "proof": [
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+  ],
+  "desc": "sizes match but proof is not empty and sizes are zero",
+  "wantErr": true
+}


### PR DESCRIPTION
This PR adds subtree consistency tests for subtree starting at 0. These are the same tests that are used for consistency tests. We'll add more tests with inner subtrees later.

Towards #225.